### PR TITLE
#28 Adds newline after function declarations

### DIFF
--- a/src/__tests__/__snapshots__/function_exports.spec.js.snap
+++ b/src/__tests__/__snapshots__/function_exports.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle exported es module functions 1`] = `
+"declare export function routerReducer(state?: RouterState, action?: Action): RouterState
+declare export function syncHistoryWithStore(
+    history: History,
+    store: Store<any>,
+    options?: SyncHistoryWithStoreOptions): History & HistoryUnsubscribe"
+`;

--- a/src/__tests__/function_exports.spec.js
+++ b/src/__tests__/function_exports.spec.js
@@ -1,0 +1,10 @@
+import compiler from '../cli/compiler';
+import beautify from '../cli/beautifier';
+
+it('should handle exported es module functions', () => {
+  const ts = `export function routerReducer(state?: RouterState, action?: Action): RouterState;
+export function syncHistoryWithStore(history: History, store: Store<any>, options?: SyncHistoryWithStoreOptions): History & HistoryUnsubscribe;
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot()
+});

--- a/src/cli/__tests__/__snapshots__/compiler.spec.js.snap
+++ b/src/cli/__tests__/__snapshots__/compiler.spec.js.snap
@@ -1,5 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should handle bounded polymorphism 1`] = `"declare function fooGood<T>(obj: T): T"`;
+exports[`should handle bounded polymorphism 1`] = `
+"declare function fooGood<T>(obj: T): T
+"
+`;
 
 exports[`should handle maybe & nullable type 1`] = `"declare var a: string | null | void;"`;

--- a/src/cli/__tests__/__snapshots__/fixtures.spec.js.snap
+++ b/src/cli/__tests__/__snapshots__/fixtures.spec.js.snap
@@ -912,12 +912,14 @@ section of code to evaluate across multiple tick cycles.
  * @param  the function to run asynchronously
 */
 declare function schedule(asyncFunction: Scheduleable): void
+
 	
 /**
  * Fails a build, outputting a specific reason for failing into a HTML table.
  * @param  the String to output
 */
 declare function fail(message: MarkdownString): void
+
 	
 /**
  * Highlights low-priority issues, but does not fail the build. Message
@@ -925,6 +927,7 @@ declare function fail(message: MarkdownString): void
  * @param  the String to output
 */
 declare function warn(message: MarkdownString): void
+
 	
 /**
  * Adds a message to the Danger table, the only difference between this
@@ -932,12 +935,14 @@ declare function warn(message: MarkdownString): void
  * @param  the String to output
 */
 declare function message(message: MarkdownString): void
+
 	
 /**
  * Adds raw markdown into the Danger comment, under the table
  * @param  the String to output
 */
 declare function markdown(message: MarkdownString): void
+
 	declare var danger: DangerDSLType;
 	declare var peril: PerilDSL;
 	declare var results: DangerRuntimeContainer;

--- a/src/printers/function.js
+++ b/src/printers/function.js
@@ -10,7 +10,7 @@ export const functionType = (func: RawNode, dotAsReturn: boolean = false) => {
 
   const firstPass = `${generics}(${params.join(', ')})${dotAsReturn ? ':' : ' =>'} ${returns}`;
 
-  // Make sure our functions arent too wide
+  // Make sure our functions aren't too wide
   if (firstPass.length > 80) {
     // break params onto a new line for better formatting
     const paramsWithNewlines = `\n${params.join(',\n')}`;
@@ -22,7 +22,8 @@ export const functionType = (func: RawNode, dotAsReturn: boolean = false) => {
 }
 
 export const functionDeclaration = (nodeName: string, node: RawNode) => {
-  let str = `declare ${printers.relationships.exporter(node)}function ${nodeName}${functionType(node, true)}`;
+  // each functionDeclaration gets it's own line
+  let str = `declare ${printers.relationships.exporter(node)}function ${nodeName}${functionType(node, true)}\n`;
 
   return str;
 }


### PR DESCRIPTION
This PR adds a newline after each function declaration. This fixes the issue where ES module function exports were being joined onto the same line. This might be too naive a fix, but I am open to digging in more.

Fixes #28 