### PR TITLE
Added shelljs to automatically create output folder and subfolders.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lodash": "^4.17.4",
     "paralleljs": "^0.2.1",
     "prettier": "^1.12.1",
+    "shelljs": "^0.8.2",
     "typescript": "~2.4.2",
     "typescript-compiler": "^1.4.1-2"
   },

--- a/src/cli/beautifier.js
+++ b/src/cli/beautifier.js
@@ -2,5 +2,5 @@
 import prettier from "prettier";
 
 export default function beautify(str: string) {
-  return prettier.format(str);
+  return prettier.format(str, { parser: "flow" });
 }

--- a/src/cli/compiler.js
+++ b/src/cli/compiler.js
@@ -24,7 +24,7 @@ const compile = sourceFile => {
  */
 export default {
   compileTest: (path: string, target: string) => {
-    tsc.compile(path, "--module commonjs -t ES5 --out " + target);
+    tsc.compile(path, "--module commonjs -t ES6 --out " + target);
   },
 
   compileDefinitionString: (string: string) => {

--- a/src/cli/flow-typed-exporter.js
+++ b/src/cli/flow-typed-exporter.js
@@ -1,5 +1,6 @@
 // @flow
 import fs from "fs";
+import shell from "shelljs";
 
 export default function exportForFlowTyped(moduleName: string, output: string) {
   const folder = "../exports/" + moduleName + "_v1.x.x";
@@ -8,9 +9,9 @@ export default function exportForFlowTyped(moduleName: string, output: string) {
   const testfilePath = folder + "/test_" + moduleName + ".js";
 
   if (!fs.existsSync(folder)) {
-    fs.mkdirSync(folder);
+    shell.mkdir('-p', folder);
     fs.existsSync(folder + "/flow_v0.35.x-") ||
-      fs.mkdirSync(folder + "/flow_v0.35.x-");
+      shell.mkdir('-p', folder + "/flow_v0.35.x-");
   }
 
   fs.writeFileSync(testfilePath, "");


### PR DESCRIPTION
This change adds shelljs to recursively create the output directory.

It also modifies prettier to use the flow parser to deal with warnings from prettier regarding a parser not being specified. It would default to babel without this change.

I also changed the tsc options to use ES6 since other parts in the file mention `ts.ScriptTarget.ES6`. It would be nice to make this a configuration option in the future.

Please note that unrelated to this change, I am now getting errors from the master branch of this code which are not present in the NPM version. I'm not sure why there's a difference.

```
{ SyntaxError: `declare export type` is not supported. Use `export type` instead (15:18)
  13 | View: typeof View,
  14 | Node: typeof Node
> 15 | };declare export type MyType = MyConfigTypes;declare module.exports: typeof MyComponent
```