### PR TITLE
Support LiteralType

### DIFF
--- a/src/cli/beautifier.js
+++ b/src/cli/beautifier.js
@@ -2,5 +2,7 @@
 import prettier from "prettier";
 
 export default function beautify(str: string) {
-  return prettier.format(str);
+  return prettier.format(str, {
+      parser: "babylon"
+  });
 }

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -145,6 +145,9 @@ export const printType = (type: RawNode) => {
 
     case SyntaxKind.IntersectionType:
       return type.types.map(printType).join(" & ");
+      
+    case SyntaxKind.LiteralType:
+      return type.value;
 
     case SyntaxKind.SymbolKeyword:
       // TODO: What to print here?


### PR DESCRIPTION
It also fixes `No parser and no filepath given, using 'babylon' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.` error