### PR TITLE
Remove this annotation in function declarations

### DIFF
--- a/src/__tests__/__snapshots__/function_exports.spec.js.snap
+++ b/src/__tests__/__snapshots__/function_exports.spec.js.snap
@@ -12,3 +12,8 @@ declare export function syncHistoryWithStore(
 ): History & HistoryUnsubscribe;
 "
 `;
+
+exports[`should remove this annotation from functions 1`] = `
+"declare function addClickListener(onclick: (e: Event) => void): void;
+"
+`;

--- a/src/__tests__/function_exports.spec.js
+++ b/src/__tests__/function_exports.spec.js
@@ -8,3 +8,10 @@ export function syncHistoryWithStore(history: History, store: Store<any>, option
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
 });
+
+it("should remove this annotation from functions", () => {
+  const ts =
+    "function addClickListener(onclick: (this: void, e: Event) => void): void;";
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/printers/function.js
+++ b/src/printers/function.js
@@ -4,7 +4,9 @@ import type { RawNode } from "../nodes/node";
 import printers from "./index";
 
 export const functionType = (func: RawNode, dotAsReturn: boolean = false) => {
-  const params = func.parameters.map(printers.common.parameter);
+  const params = func.parameters
+    .filter(param => param.name.text !== "this")
+    .map(printers.common.parameter);
   const generics = printers.common.generics(func.typeParameters);
   const returns = func.type ? printers.node.printType(func.type) : "void";
 


### PR DESCRIPTION
flow doesn't have support for [`this` annotation](https://www.typescriptlang.org/docs/handbook/functions.html) in functions: https://github.com/facebook/flow/issues/452

This will result in prettier failing to parse the generated code. This PR removes the this annotation in function declarations.