### PR TITLE
Add support for exported interfaces

### DIFF
--- a/src/__tests__/__snapshots__/interface_exports.spec.js.snap
+++ b/src/__tests__/__snapshots__/interface_exports.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle exported interfaces 1`] = `
+"export interface UnaryFunction<T, R> {
+  (source: T): R;
+}
+"
+`;

--- a/src/__tests__/interface_exports.spec.js
+++ b/src/__tests__/interface_exports.spec.js
@@ -1,0 +1,11 @@
+// @flow
+import compiler from "../cli/compiler";
+import beautify from "../cli/beautifier";
+
+it("should handle exported interfaces", () => {
+  const ts = `export interface UnaryFunction<T, R> {
+    (source: T): R;
+  }
+`;
+  expect(beautify(compiler.compileDefinitionString(ts))).toMatchSnapshot();
+});

--- a/src/printers/declarations.js
+++ b/src/printers/declarations.js
@@ -60,11 +60,10 @@ export const interfaceDeclaration = (nodeName: string, node: RawNode) => {
 
   const type = node.heritageClauses ? "type" : "interface";
 
-  let str = `declare ${printers.relationships.exporter(
-    node,
-  )}${type} ${nodeName}${printers.common.generics(node.typeParameters)} ${
-    type === "type" ? "= " : ""
-  }${interfaceType(node)} ${heritage}`;
+  let str = `${printers.relationships.exporter(node) ||
+    "declare "}${type} ${nodeName}${printers.common.generics(
+    node.typeParameters,
+  )} ${type === "type" ? "= " : ""}${interfaceType(node)} ${heritage}`;
 
   return str;
 };


### PR DESCRIPTION
The syntax `declare export interface` isn't supported by flow. Instead `export interface` should be used