### PR TITLE
Add support for exported types

### DIFF
--- a/src/__tests__/__snapshots__/type_exports.spec.js.snap
+++ b/src/__tests__/__snapshots__/type_exports.spec.js.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle exported types 1`] = `
+"export type FactoryOrValue<T> = T | (() => T);
+"
+`;

--- a/src/__tests__/type_exports.spec.js
+++ b/src/__tests__/type_exports.spec.js
@@ -1,0 +1,8 @@
+// @flow
+import compiler from "../cli/compiler";
+import beautify from "../cli/beautifier";
+
+it("should handle exported types", () => {
+  const ts = "export declare type FactoryOrValue<T> = T | (() => T);";
+  expect(beautify(compiler.compileDefinitionString(ts))).toMatchSnapshot();
+});

--- a/src/printers/declarations.js
+++ b/src/printers/declarations.js
@@ -69,9 +69,8 @@ export const interfaceDeclaration = (nodeName: string, node: RawNode) => {
 };
 
 export const typeDeclaration = (nodeName: string, node: RawNode) => {
-  let str = `declare ${printers.relationships.exporter(
-    node,
-  )}type ${nodeName}${printers.common.generics(
+  let str = `${printers.relationships.exporter(node) ||
+    "declare "}type ${nodeName}${printers.common.generics(
     node.typeParameters,
   )} = ${printers.node.printType(node.type)};`;
 


### PR DESCRIPTION
The syntax `declare export type` isn't supported by flow. Instead `export type` should be used.

Followup up to #58