### PR TITLE
Fix exports to match README

### DIFF
--- a/src/__tests__/classes.spec.js
+++ b/src/__tests__/classes.spec.js
@@ -1,5 +1,4 @@
-import compiler from "../cli/compiler";
-import beautify from "../cli/beautifier";
+import {compiler, beautify} from "..";
 
 it("should handle static methods ES6 classes", () => {
   const ts = `class Observable<T> implements Subscribable<T> {

--- a/src/__tests__/function_exports.spec.js
+++ b/src/__tests__/function_exports.spec.js
@@ -1,5 +1,4 @@
-import compiler from "../cli/compiler";
-import beautify from "../cli/beautifier";
+import {compiler, beautify} from "..";
 
 it("should handle exported es module functions", () => {
   const ts = `export function routerReducer(state?: RouterState, action?: Action): RouterState;

--- a/src/__tests__/global_declares.spec.js
+++ b/src/__tests__/global_declares.spec.js
@@ -1,6 +1,5 @@
 // @flow
-import compiler from "../cli/compiler";
-import beautify from "../cli/beautifier";
+import {compiler, beautify} from "..";
 
 it("should handle declared interfaces", () => {
   const ts = `

--- a/src/__tests__/interface_exports.spec.js
+++ b/src/__tests__/interface_exports.spec.js
@@ -1,6 +1,5 @@
 // @flow
-import compiler from "../cli/compiler";
-import beautify from "../cli/beautifier";
+import {compiler, beautify} from "..";
 
 it("should handle exported interfaces", () => {
   const ts = `export interface UnaryFunction<T, R> {

--- a/src/__tests__/string_literals.spec.js
+++ b/src/__tests__/string_literals.spec.js
@@ -1,5 +1,4 @@
-import compiler from "../cli/compiler";
-import beautify from "../cli/beautifier";
+import {compiler, beautify} from "..";
 
 it("should handle string literals in function argument \"overloading\"", () => {
   const ts = `

--- a/src/__tests__/type_exports.spec.js
+++ b/src/__tests__/type_exports.spec.js
@@ -1,6 +1,5 @@
 // @flow
-import compiler from "../cli/compiler";
-import beautify from "../cli/beautifier";
+import {compiler, beautify} from "..";
 
 it("should handle exported types", () => {
   const ts = "export declare type FactoryOrValue<T> = T | (() => T);";

--- a/src/__tests__/union_strings.spec.js
+++ b/src/__tests__/union_strings.spec.js
@@ -1,5 +1,4 @@
-import compiler from "../cli/compiler";
-import beautify from "../cli/beautifier";
+import {compiler, beautify} from "..";
 
 it("should handle union strings", () => {
   const ts = `

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
-import compiler from "./cli/compiler";
-import beautify from "./cli/beautifier";
+import compiler from './cli/compiler';
+import beautify from './cli/beautifier';
+
+export {default as compiler} from './cli/compiler';
+
+export {default as beautify} from './cli/beautifier';
 
 export default {
   beautify,

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import compiler from './cli/compiler';
-import beautify from './cli/beautifier';
+import compiler from "./cli/compiler";
+import beautify from "./cli/beautifier";
 
-export {default as compiler} from './cli/compiler';
+export {default as compiler} from "./cli/compiler";
 
-export {default as beautify} from './cli/beautifier';
+export {default as beautify} from "./cli/beautifier";
 
 export default {
   beautify,


### PR DESCRIPTION
The readme says to import from `flowgen` like so:

```javascript
import { compiler, beautify } from 'flowgen';
```

However this would break, since they're currently both in the default export of `flowgen`:

```javascript
export default {
  compiler,
  beautify
};
```

This means that they'd need to imported like so:

```javascript
import flowgen from 'flowgen';
const { compiler, beautify } = flowgen;
```

To make the imports work like in the README, this needed to be added:

```javascript
export {default as compiler} from './cli/compiler';
export {default as beautify} from './cli/beautifier';
```

Now any of the above import examples will work.