### PR TITLE
Correctly handle boolean literals in types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flowgen",
   "description": "Generate flowtype definition files from TypeScript",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "bin": {
     "flowgen": "./lib/cli/index.js"
   },

--- a/src/__tests__/__snapshots__/boolean_literals.spec.js.snap
+++ b/src/__tests__/__snapshots__/boolean_literals.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle boolean literals in type 1`] = `
+"declare type MyFalsyType = string | false;
+declare type MyTruthyType = true | string;
+"
+`;

--- a/src/__tests__/boolean_literals.spec.js
+++ b/src/__tests__/boolean_literals.spec.js
@@ -1,0 +1,12 @@
+import {compiler, beautify} from "..";
+
+it("should handle boolean literals in type", () => {
+  const ts = `
+  type MyFalsyType = string | false;
+  type MyTruthyType = true | string;
+`;
+
+  const result = compiler.compileDefinitionString(ts);
+
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/printers/basics.js
+++ b/src/printers/basics.js
@@ -8,6 +8,8 @@ const types = {
   NullKeyword: "null",
   UndefinedKeyword: "void",
   ObjectKeyword: "{[key: string]: any}",
+  FalseKeyword: "false",
+  TrueKeyword: "true"
 };
 
 export const print = (kind: string): string => {

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -10,13 +10,6 @@ import printers from "./index";
 export const printType = (type: RawNode) => {
   // debuggerif()
   //TODO: #6 No match found in SyntaxKind enum
-  switch (type.kind) {
-    case "FunctionTypeAnnotation":
-      return printers.functions.functionType(type);
-
-    case "LastNodeType":
-      return `"${type.literal.text}"`;
-  }
 
   const keywordPrefix =
     type.modifiers &&
@@ -33,9 +26,12 @@ export const printType = (type: RawNode) => {
     case SyntaxKind.NullKeyword:
     case SyntaxKind.UndefinedKeyword:
     case SyntaxKind.ObjectKeyword:
+    case SyntaxKind.FalseKeyword:
+    case SyntaxKind.TrueKeyword:
       return printers.basics.print(type.kind);
 
     case SyntaxKind.FunctionType:
+    case SyntaxKind.FunctionTypeAnnotation:
       return printers.functions.functionType(type);
 
     case SyntaxKind.TypeLiteral:
@@ -55,9 +51,11 @@ export const printType = (type: RawNode) => {
     case SyntaxKind.TypePredicate:
       if (type.literal) {
         if (type.literal.kind === "StringLiteral") {
-          return "'" + type.literal.text + "'";
-        } else {
+          return printType(type.literal);
+        } else if (type.literal.text) {
           return type.literal.text;
+        } else {
+          return printType(type.literal);
         }
       }
 
@@ -76,8 +74,7 @@ export const printType = (type: RawNode) => {
       );
 
     case SyntaxKind.StringLiteral:
-      debugger;
-      return type.text;
+      return "'" + type.text + "'";
 
     case SyntaxKind.TypeReference:
       return printers.declarations.typeReference(type);


### PR DESCRIPTION
Previously a definition like `type MyFalsyType = string | false;` had been compiling to `type MyFalsyType = string | ;` and thus breaking things. Fix the issue by handling true/false literals.