### PR TITLE
Add generics to call signature and more

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,6 @@
 [ignore]
 <PROJECT_ROOT>/node_modules/.*
-.*/__tests__/.*
+.*/__snapshots__/.*
 <PROJECT_ROOT>/lib/.*
 
 [include]
@@ -14,7 +14,12 @@ flow-typed
 [version]
 >= 0.37.0
 
+[lints]
+all=warn
+untyped-type-import=error
+
 [options]
+include_warnings=true
 suppress_comment= \\(.\\|\n\\)*\\--FlowIgnore
 
 module.name_mapper.extension='scss' -> '<PROJECT_ROOT>/src/typings/css-modules.js'
@@ -30,3 +35,9 @@ module.file_ext=.json
 module.file_ext=.jsx
 module.file_ext=.css
 module.file_ext=.scss
+
+[strict]
+nonstrict-import
+unsafe-getters-setters
+untyped-import
+untyped-type-import

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+export type Options = {
+  jsdoc?: boolean;
+  interfaceRecords?: boolean;
+  stringEnums?: boolean;
+};
+
+export type Compiler = {
+  compileTest(path: string, target: string): void;
+  compileDefinitionString(string: string, options?: Options): string;
+  compileDefinitionFile(path: string, options?: Options): string;
+};
+
+type Flowgen = {
+  beautify(str: string): string;
+  compiler: Compiler;
+};
+
+export default Flowgen;

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,0 +1,20 @@
+// @flow strict
+
+export type Options = {|
+  jsdoc?: boolean,
+  interfaceRecords?: boolean,
+  stringEnums?: boolean,
+|};
+
+export type Compiler = {|
+  compileTest(path: string, target: string): void,
+  compileDefinitionString(string: string, options?: Options): string,
+  compileDefinitionFile(path: string, options?: Options): string,
+|};
+
+declare type Flowgen = {|
+  beautify(str: string): string,
+  compiler: Compiler,
+|};
+
+declare export default Flowgen;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "flowgen",
   "description": "Generate flowtype definition files from TypeScript",
   "version": "1.5.0",
+  "typings": "index.d.ts",
   "bin": {
     "flowgen": "./lib/cli/index.js"
   },
@@ -42,7 +43,9 @@
     "jest": "^23.6.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "index.d.ts",
+    "index.js.flow"
   ],
   "license": "ISC",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prettier": "prettier  --write \"{src,types}/**/*.js\"",
-    "compile": "babel --out-dir lib ./src",
+    "compile": "babel ./src --out-dir lib --delete-dir-on-start --ignore 'src/**/*.spec.js'",
     "compile:watch": "npm run compile -- -w",
     "test": "jest"
   }

--- a/src/__tests__/__snapshots__/interfaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.js.snap
@@ -64,6 +64,16 @@ exports[`should handle single interface 2`] = `
 "
 `;
 
+exports[`should support call signature 1`] = `
+"declare interface ObjectSchemaConstructor {
+  <T: { [key: string]: any }>(
+    fields?: ObjectSchemaDefinition<T>
+  ): ObjectSchema<T>;
+  new(): ObjectSchema<{}>;
+}
+"
+`;
+
 exports[`should support readonly modifier 1`] = `
 "declare interface Helper {
   +name: string;

--- a/src/__tests__/basic.spec.js
+++ b/src/__tests__/basic.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle basic keywords", () => {

--- a/src/__tests__/boolean_literals.spec.js
+++ b/src/__tests__/boolean_literals.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import {compiler, beautify} from "..";
 
 it("should handle boolean literals in type", () => {

--- a/src/__tests__/classes.spec.js
+++ b/src/__tests__/classes.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import {compiler, beautify} from "..";
 
 it("should handle static methods ES6 classes", () => {

--- a/src/__tests__/enums.spec.js
+++ b/src/__tests__/enums.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle empty enums", () => {

--- a/src/__tests__/exports.spec.js
+++ b/src/__tests__/exports.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle exports", () => {

--- a/src/__tests__/function_exports.spec.js
+++ b/src/__tests__/function_exports.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle exported es module functions", () => {

--- a/src/__tests__/global_declares.spec.js
+++ b/src/__tests__/global_declares.spec.js
@@ -1,5 +1,6 @@
 // @flow
-import {compiler, beautify} from "..";
+
+import { compiler, beautify } from "..";
 
 it("should handle declared interfaces", () => {
   const ts = `
@@ -10,5 +11,3 @@ declare interface ICustomMessage {
 `;
   expect(beautify(compiler.compileDefinitionString(ts))).toMatchSnapshot();
 });
-
-

--- a/src/__tests__/imports.spec.js
+++ b/src/__tests__/imports.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle imports", () => {

--- a/src/__tests__/interface_exports.spec.js
+++ b/src/__tests__/interface_exports.spec.js
@@ -1,5 +1,6 @@
 // @flow
-import {compiler, beautify} from "..";
+
+import { compiler, beautify } from "..";
 
 it("should handle exported interfaces", () => {
   const ts = `export interface UnaryFunction<T, R> {

--- a/src/__tests__/interfaces.spec.js
+++ b/src/__tests__/interfaces.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle single interface", () => {

--- a/src/__tests__/interfaces.spec.js
+++ b/src/__tests__/interfaces.spec.js
@@ -74,3 +74,14 @@ interface Helper {
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
 });
+
+it("should support call signature", () => {
+  const ts = `
+  declare interface ObjectSchemaConstructor {
+    <T extends object>(fields?: ObjectSchemaDefinition<T>): ObjectSchema<T>;
+    new (): ObjectSchema<{}>;
+  }
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/__tests__/jsdoc.spec.js
+++ b/src/__tests__/jsdoc.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle basic jsdoc", () => {

--- a/src/__tests__/mapped_types.spec.js
+++ b/src/__tests__/mapped_types.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle mapped types", () => {

--- a/src/__tests__/modules.spec.js
+++ b/src/__tests__/modules.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle module", () => {

--- a/src/__tests__/namespaces.spec.js
+++ b/src/__tests__/namespaces.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle namespaces", () => {

--- a/src/__tests__/string_literals.spec.js
+++ b/src/__tests__/string_literals.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import {compiler, beautify} from "..";
 
 it("should handle string literals in function argument \"overloading\"", () => {

--- a/src/__tests__/type_exports.spec.js
+++ b/src/__tests__/type_exports.spec.js
@@ -1,4 +1,5 @@
 // @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle exported types", () => {

--- a/src/__tests__/union_strings.spec.js
+++ b/src/__tests__/union_strings.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle union strings", () => {

--- a/src/__tests__/utility_types.spec.js
+++ b/src/__tests__/utility_types.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle utility types", () => {

--- a/src/__tests__/value_exports.spec.js
+++ b/src/__tests__/value_exports.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { compiler, beautify } from "..";
 
 it("should handle exported es module values", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
+// @flow
+
 import compiler from "./cli/compiler";
 import beautify from "./cli/beautifier";
 
-export {default as compiler} from "./cli/compiler";
+export { default as compiler } from "./cli/compiler";
 
-export {default as beautify} from "./cli/beautifier";
+export { default as beautify } from "./cli/beautifier";
 
 export default {
   beautify,

--- a/src/options.js
+++ b/src/options.js
@@ -1,9 +1,9 @@
 //@flow
 
 export type Options = {|
-  jsdoc: boolean,
-  interfaceRecords: boolean,
-  stringEnums: boolean,
+  jsdoc?: boolean,
+  interfaceRecords?: boolean,
+  stringEnums?: boolean,
 |};
 
 const defaultOptions: Options = Object.freeze({

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -39,7 +39,7 @@ export const printType = (type: RawNode): string => {
     }
 
     case SyntaxKind.FunctionType:
-    //case SyntaxKind.FunctionTypeAnnotation:
+      //case SyntaxKind.FunctionTypeAnnotation:
       return printers.functions.functionType(type);
 
     case SyntaxKind.TypeLiteral:
@@ -212,7 +212,8 @@ export const printType = (type: RawNode): string => {
       return printers.common.parameter(type);
 
     case SyntaxKind.CallSignature: {
-      let str = `(${type.parameters
+      const generics = printers.common.generics(type.typeParameters);
+      const str = `${generics}(${type.parameters
         .map(printers.common.parameter)
         .join(", ")})`;
       return type.type ? `${str}: ${printType(type.type)}` : str;

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -56,11 +56,17 @@ export const printType = (type: RawNode): string => {
       );
 
     case SyntaxKind.BindingElement:
-    case SyntaxKind.TypeParameter:
+    case SyntaxKind.TypeParameter: {
+      let defaultType = "";
+      let constraint = "";
       if (type.constraint) {
-        return `${type.name.text}: ${printType(type.constraint)}`;
+        constraint = `: ${printType(type.constraint)}`;
       }
-      return type.name.text;
+      if (type.default) {
+        defaultType = `= ${printType(type.default)}`;
+      }
+      return `${type.name.text}${constraint}${defaultType}`;
+    }
 
     case SyntaxKind.PrefixUnaryExpression:
       switch (type.operator) {


### PR DESCRIPTION
* Add TypeScript and Flow types
```
"typings": "index.d.ts",
"files": [
  "lib",
  "index.d.ts",
  "index.js.flow"
],
```
* Use `babel ./src --out-dir lib --delete-dir-on-start --ignore 'src/**/*.spec.js'` so it doesn't compile `__tests__` to lib