### PR TITLE
Don't choke on toString property name

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "sourceType": "module"
   },
   "env": {
+    "es6": true,
     "node": true
   },
   "rules": {

--- a/src/__tests__/__snapshots__/function_exports.spec.js.snap
+++ b/src/__tests__/__snapshots__/function_exports.spec.js.snap
@@ -30,6 +30,13 @@ declare export function routerReducer(state?: RouterState): RouterState;
 "
 `;
 
+exports[`should handle toString function overload 1`] = `
+"declare export function toString(): void;
+declare export function toString(e: number): void;
+declare export function toString(b: string): void;
+"
+`;
+
 exports[`should remove this annotation from functions 1`] = `
 "declare function addClickListener(onclick: (e: Event) => void): void;
 "

--- a/src/__tests__/__snapshots__/interfaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.js.snap
@@ -64,6 +64,13 @@ exports[`should handle single interface 2`] = `
 "
 `;
 
+exports[`should handle toString property name 1`] = `
+"declare interface A {
+  toString(): string;
+}
+"
+`;
+
 exports[`should support call signature 1`] = `
 "declare interface ObjectSchemaConstructor {
   <T: { [key: string]: any }>(

--- a/src/__tests__/function_exports.spec.js
+++ b/src/__tests__/function_exports.spec.js
@@ -10,6 +10,15 @@ export function syncHistoryWithStore(history: History, store: Store<any>, option
   expect(beautify(result)).toMatchSnapshot();
 });
 
+it("should handle toString function overload", () => {
+  const ts = `export function toString(): void;
+export function toString(e: number): void;
+export function toString(b: string): void;
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});
+
 it("should handle default exported es module functions", () => {
   const ts = `export default function routerReducer(state?: RouterState, action?: Action): RouterState;`;
   const result = compiler.compileDefinitionString(ts);

--- a/src/__tests__/interfaces.spec.js
+++ b/src/__tests__/interfaces.spec.js
@@ -98,3 +98,13 @@ interface Example<State> {
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
 });
+
+it("should handle toString property name", () => {
+  const ts = `
+interface A {
+  toString(): string;
+}
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/namespaceManager.js
+++ b/src/namespaceManager.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-let namespaceProps = {};
+let namespaceProps = Object.create(null);
 let namespaces: Array<string> = [];
 
 let context: string = "";
@@ -15,7 +15,7 @@ export default {
   setContext: (namespace: string) => (context = namespace),
 
   reset: () => {
-    namespaceProps = {};
+    namespaceProps = Object.create(null);
     namespaces = [];
   },
 };

--- a/src/nodes/factory.js
+++ b/src/nodes/factory.js
@@ -17,9 +17,9 @@ export class Factory {
   _functionDeclarations: Object;
 
   constructor() {
-    this._modules = {};
-    this._propDeclarations = {};
-    this._functionDeclarations = {};
+    this._modules = Object.create(null);
+    this._propDeclarations = Object.create(null);
+    this._functionDeclarations = Object.create(null);
   }
 
   // If multiple declarations are found for the same module name

--- a/src/nodes/node.js
+++ b/src/nodes/node.js
@@ -18,7 +18,7 @@ export default class Node<NodeType = RawNode> {
   module: ?string;
 
   constructor(node: ?NodeType) {
-    this.children = {};
+    this.children = Object.create(null);
 
     if (node) {
       this.raw = stripDetailsFromTree(node);

--- a/src/printers/identifiers.js
+++ b/src/printers/identifiers.js
@@ -9,6 +9,12 @@ const identifiers = {
   NonNullable: "$NonMaybeType",
 };
 
+// TODO: Object.entries should be fixed when Flow will switch to exact by default
+// We use Map, so it doesn't fail with `toString` identifier
+const identifiersMap: Map<string, string> = new Map(
+  (Object.entries(identifiers): any),
+);
+
 export const print = (kind: string): string => {
-  return identifiers[kind] || kind;
+  return identifiersMap.get(kind) || kind;
 };

--- a/src/printers/identifiers.js
+++ b/src/printers/identifiers.js
@@ -2,19 +2,14 @@
 
 // Please add only built-in type references
 
-const identifiers = {
+const identifiers = Object.create(null);
+Object.assign(identifiers, {
   ReadonlyArray: "$ReadOnlyArray",
   Partial: "$Shape",
   Readonly: "$ReadOnly",
   NonNullable: "$NonMaybeType",
-};
-
-// TODO: Object.entries should be fixed when Flow will switch to exact by default
-// We use Map, so it doesn't fail with `toString` identifier
-const identifiersMap: Map<string, string> = new Map(
-  (Object.entries(identifiers): any),
-);
+});
 
 export const print = (kind: string): string => {
-  return identifiersMap.get(kind) || kind;
+  return identifiers[kind] || kind;
 };


### PR DESCRIPTION
```ts
interface A {
  function toString() { [native code] }(): string
}
```

🤯 