### PR TITLE
Rename JSX.Element to React$Node

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -16,6 +16,7 @@ flow-typed
 
 [lints]
 all=warn
+dynamic-export=off
 untyped-type-import=error
 
 [options]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-flowtype": "^3.2.1",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jest": "^22.2.2",
-    "flow-bin": "^0.92.1",
+    "flow-bin": "^0.94.0",
     "jest": "^23.6.0"
   },
   "files": [

--- a/src/__tests__/__snapshots__/interfaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.js.snap
@@ -124,6 +124,7 @@ exports[`should support call signature 1`] = `
 
 exports[`should support omitting generic defaults in types, classes, interfaces 1`] = `
 "declare interface Foo<T = Symbol, U = number> {}
+declare type FooBar = {} & Foo<>;
 declare type Bar<T = number, U = string> = {};
 declare class Baz<T = string, U = number> {}
 declare var a: Foo<>;

--- a/src/__tests__/__snapshots__/interfaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.js.snap
@@ -129,6 +129,9 @@ declare class Baz<T = string, U = number> {}
 declare var a: Foo<>;
 declare var b: Bar<>;
 declare var c: Baz<>;
+declare var d: Foo<any>;
+declare var e: Bar<any>;
+declare var f: Baz<any>;
 "
 `;
 

--- a/src/__tests__/__snapshots__/interfaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.js.snap
@@ -122,6 +122,16 @@ exports[`should support call signature 1`] = `
 "
 `;
 
+exports[`should support omitting generic defaults in types, classes, interfaces 1`] = `
+"declare interface Foo<T = Symbol, U = number> {}
+declare type Bar<T = number, U = string> = {};
+declare class Baz<T = string, U = number> {}
+declare var a: Foo<>;
+declare var b: Bar<>;
+declare var c: Baz<>;
+"
+`;
+
 exports[`should support optional methods 1`] = `
 "declare interface Example<State> {
   required<R>(value: any, state: State): true;

--- a/src/__tests__/__snapshots__/mapped_types.spec.js.snap
+++ b/src/__tests__/__snapshots__/mapped_types.spec.js.snap
@@ -17,5 +17,6 @@ declare type MappedObj = $ObjMapi<
   SourceObject,
   <K>(K) => Ref<$ElementType<SourceObject, K>>
 >;
+declare type ConstantKey = $PropertyType<MappedObj, \\"a\\">;
 "
 `;

--- a/src/__tests__/__snapshots__/module_identifiers.spec.js.snap
+++ b/src/__tests__/__snapshots__/module_identifiers.spec.js.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should handle utility types 1`] = `
+exports[`should handle global types jsx 1`] = `
+"import * as React from \\"react\\";
+declare function s(node: React$Node): void;
+declare type Props = {
+  children: React$Node
+};
+declare class Component mixins React.Component<Props> {
+  render(): React$Node;
+}
+"
+`;
+
+exports[`should handle react types 1`] = `
 "import { Node } from \\"react\\";
 import * as React from \\"react\\";
 declare function s(node: Node): void;

--- a/src/__tests__/__snapshots__/namespaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.js.snap
@@ -5,6 +5,13 @@ exports[`should handle exported interfaces and types 1`] = `
 "
 `;
 
+exports[`should handle global augmentation 1`] = `
+"declare module \\"global\\" {
+  declare interface Array<T> {}
+}
+"
+`;
+
 exports[`should handle namespace function merging 1`] = `
 "declare var npm$namespace$test: {
   test: typeof test$test

--- a/src/__tests__/__snapshots__/namespaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.js.snap
@@ -13,7 +13,9 @@ exports[`should handle global augmentation 1`] = `
 `;
 
 exports[`should handle namespace function merging 1`] = `
-"declare var npm$namespace$test: {
+"declare var test: typeof npm$namespace$test;
+
+declare var npm$namespace$test: {
   test: typeof test$test
 };
 declare function test$test(err: number): void;
@@ -23,7 +25,9 @@ declare function test$test(response: string): string;
 `;
 
 exports[`should handle namespace merging 1`] = `
-"declare var npm$namespace$test: {
+"declare var test: typeof npm$namespace$test;
+
+declare var npm$namespace$test: {
   ok: typeof test$ok,
   error: typeof test$error
 };
@@ -34,7 +38,9 @@ declare export var test$error: string;
 `;
 
 exports[`should handle namespaces 1`] = `
-"declare var npm$namespace$test: {
+"declare var test: typeof npm$namespace$test;
+
+declare var npm$namespace$test: {
   ok: typeof test$ok
 };
 declare export var test$ok: number;
@@ -43,6 +49,7 @@ declare export var test$ok: number;
 
 exports[`should handle nested namespaces 1`] = `
 "import * as external from \\"external\\";
+declare var E0: typeof npm$namespace$E0;
 
 declare var npm$namespace$E0: {
   s1: typeof E0$s1,
@@ -100,7 +107,9 @@ declare var E0$s1: string;
 `;
 
 exports[`should handle qualified namespaces 1`] = `
-"declare var npm$namespace$A: {
+"declare var A: typeof npm$namespace$A;
+
+declare var npm$namespace$A: {
   B: typeof npm$namespace$A$B
 };
 

--- a/src/__tests__/__snapshots__/utility_types.spec.js.snap
+++ b/src/__tests__/__snapshots__/utility_types.spec.js.snap
@@ -9,5 +9,16 @@ declare type B = $Shape<{
 }>;
 declare type C = $NonMaybeType<string | null>;
 declare type D = $ReadOnlyArray<string>;
+declare type E = $Call<() => string>;
+declare type A1<Readonly> = Readonly;
+declare type B1<Partial> = Partial;
+declare type C1<NonNullable> = NonNullable;
+declare type D1<ReadonlyArray> = ReadonlyArray;
+declare type E1<ReturnType> = ReturnType;
+declare type A2<T> = $ReadOnly<T>;
+declare type B2<T> = $Shape<T>;
+declare type C2<T> = $NonMaybeType<T>;
+declare type D2<T> = $ReadOnlyArray<T>;
+declare type E2<T> = $Call<() => T>;
 "
 `;

--- a/src/__tests__/interfaces.spec.js
+++ b/src/__tests__/interfaces.spec.js
@@ -118,8 +118,8 @@ interface AbstractLevelDOWNConstructor {
 
 it("should support omitting generic defaults in types, classes, interfaces", () => {
   const ts = `
-interface Foo<T = symbol, U = number> {
-}  
+interface Foo<T = symbol, U = number> {}
+interface FooBar extends Foo {}
 type Bar<T = number, U = string> = {}
 class Baz<T = string, U = number> {}
 

--- a/src/__tests__/interfaces.spec.js
+++ b/src/__tests__/interfaces.spec.js
@@ -126,6 +126,10 @@ class Baz<T = string, U = number> {}
 declare var a: Foo
 declare var b: Bar
 declare var c: Baz
+
+declare var d: Foo<any>
+declare var e: Bar<any>
+declare var f: Baz<any>
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();

--- a/src/__tests__/interfaces.spec.js
+++ b/src/__tests__/interfaces.spec.js
@@ -116,6 +116,21 @@ interface AbstractLevelDOWNConstructor {
   expect(beautify(result)).toMatchSnapshot();
 });
 
+it("should support omitting generic defaults in types, classes, interfaces", () => {
+  const ts = `
+interface Foo<T = symbol, U = number> {
+}  
+type Bar<T = number, U = string> = {}
+class Baz<T = string, U = number> {}
+
+declare var a: Foo
+declare var b: Bar
+declare var c: Baz
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});
+
 it("should support optional methods", () => {
   const ts = `
 interface Example<State> {

--- a/src/__tests__/mapped_types.spec.js
+++ b/src/__tests__/mapped_types.spec.js
@@ -16,6 +16,7 @@ type MappedUnion = {
 type MappedObj = {
   [K in keyof SourceObject]: Ref<SourceObject[K]>
 }
+type ConstantKey = MappedObj["a"]
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();

--- a/src/__tests__/module_identifiers.spec.js
+++ b/src/__tests__/module_identifiers.spec.js
@@ -2,7 +2,7 @@
 
 import { compiler, beautify } from "..";
 
-it("should handle utility types", () => {
+it("should handle react types", () => {
   const ts = `
 import {ReactNode} from 'react'
 import * as React from 'react'
@@ -11,4 +11,21 @@ declare function s(node: React.ReactNode): void;
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+});
+
+describe("should handle global types", () => {
+  test("jsx", () => {
+    const ts = `
+import * as React from 'react'
+declare function s(node: JSX.Element): void;
+
+type Props = {children: JSX.Element}
+
+declare class Component extends React.Component<Props> {
+  render(): JSX.Element
+}
+`;
+    const result = compiler.compileDefinitionString(ts);
+    expect(beautify(result)).toMatchSnapshot();
+  });
 });

--- a/src/__tests__/namespaces.spec.js
+++ b/src/__tests__/namespaces.spec.js
@@ -112,3 +112,12 @@ declare namespace A.B.C {
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
 });
+
+test("should handle global augmentation", () => {
+  const ts = `
+declare global {
+  interface Array<T> {}
+}`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/__tests__/utility_types.spec.js
+++ b/src/__tests__/utility_types.spec.js
@@ -8,6 +8,19 @@ type A = Readonly<{a: number}>
 type B = Partial<{a: number}>
 type C = NonNullable<string | null>
 type D = ReadonlyArray<string>
+type E = ReturnType<() => string>
+
+type A1<Readonly> = Readonly
+type B1<Partial> = Partial
+type C1<NonNullable> = NonNullable
+type D1<ReadonlyArray> = ReadonlyArray
+type E1<ReturnType> = ReturnType
+
+type A2<T> = Readonly<T>
+type B2<T> = Partial<T>
+type C2<T> = NonNullable<T>
+type D2<T> = ReadonlyArray<T>
+type E2<T> = ReturnType<() => T>
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();

--- a/src/nodes/namespace.js
+++ b/src/nodes/namespace.js
@@ -98,6 +98,7 @@ export default class Namespace extends Node {
       classes.length ||
       enums.length
     ) {
+      let topLevel = "";
       const nsGroup = `
       declare var npm$namespace$${name}: {
         ${uniqBy(functions, child => child.name)
@@ -126,8 +127,11 @@ export default class Namespace extends Node {
           })
           .join("\n")}
       }\n`;
+      if (namespace === "") {
+        topLevel = `declare var ${name}: typeof npm$namespace$${name};\n`;
+      }
 
-      return nsGroup + children;
+      return topLevel + nsGroup + children;
     }
 
     return children;

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -19,9 +19,18 @@ const collectNode = (
     case ts.SyntaxKind.ModuleDeclaration:
       if (
         node.flags === 4098 ||
-        (node.flags & ts.NodeFlags.Namespace) ===
-          ts.NodeFlags.Namespace /* TODO: Replace with namespace flag enum */
+        (node.flags & ts.NodeFlags.Namespace) === ts.NodeFlags.Namespace
       ) {
+        if (
+          (node.flags & ts.NodeFlags.GlobalAugmentation) ===
+          ts.NodeFlags.GlobalAugmentation
+        ) {
+          console.log("Flow doesn't support global augmentation");
+          const globalAugmentation = factory.createModuleNode(node.name.text);
+          context.addChild("module" + node.name.text, globalAugmentation);
+          traverseNode(node.body, globalAugmentation, factory);
+          break;
+        }
         const namespace = factory.createNamespaceNode(node.name.text);
 
         namespaceManager.setContext(node.name.text);

--- a/src/printers/common.js
+++ b/src/printers/common.js
@@ -117,7 +117,7 @@ export const generics = (
   types: ?$ReadOnlyArray<RawNode>,
   map?: (node: RawNode) => RawNode = node => node,
 ): string => {
-  if (types && types.length) {
+  if (types && typeof types.length !== "undefined") {
     return `<${types
       .map(map)
       .map(printers.node.printType)

--- a/src/printers/declarations.js
+++ b/src/printers/declarations.js
@@ -156,6 +156,7 @@ export const interfaceDeclaration = (
           .map(type => {
             // TODO: refactor this
             const symbol = checker.current.getSymbolAtLocation(type.expression);
+            printers.node.fixDefaultTypeArguments(symbol, type);
             if (type.expression.kind === ts.SyntaxKind.Identifier) {
               return (
                 printers.node.getFullyQualifiedPropertyAccessExpression(
@@ -223,7 +224,7 @@ export const typeReference = (node: RawNode): string => {
   }
   return (
     printers.relationships.namespaceProp(
-      printers.identifiers.print(node.typeName.escapedText),
+      printers.identifiers.print(node.typeName.text),
     ) + printers.common.generics(node.typeArguments)
   );
 };
@@ -239,6 +240,7 @@ export const classDeclaration = (nodeName: string, node: RawNode): string => {
           .map(type => {
             // TODO: refactor this
             const symbol = checker.current.getSymbolAtLocation(type.expression);
+            printers.node.fixDefaultTypeArguments(symbol, type);
             if (type.expression.kind === ts.SyntaxKind.Identifier) {
               return (
                 printers.node.getFullyQualifiedPropertyAccessExpression(

--- a/src/printers/declarations.js
+++ b/src/printers/declarations.js
@@ -6,7 +6,15 @@ import { checker } from "../checker";
 import type { RawNode } from "../nodes/node";
 import printers from "./index";
 
-export const propertyDeclaration = (node: RawNode, keywordPrefix: string) => {
+export const propertyDeclaration = (
+  node: RawNode,
+  keywordPrefix: string,
+  isVar: boolean = false,
+) => {
+  const symbol = checker.current.getSymbolAtLocation(node.name);
+  const name = isVar
+    ? printers.node.getFullyQualifiedName(symbol, node.name)
+    : printers.node.printType(node.name);
   if (
     node.modifiers &&
     node.modifiers.some(
@@ -19,24 +27,19 @@ export const propertyDeclaration = (node: RawNode, keywordPrefix: string) => {
   if (node.parameters) {
     return (
       keywordPrefix +
-      printers.node.printType(node.name) +
+      name +
       ": " +
       node.parameters.map(printers.common.parameter)
     );
   }
 
   if (node.type) {
-    return (
-      keywordPrefix +
-      printers.relationships.namespaceProp(printers.node.printType(node.name)) +
-      ": " +
-      printers.node.printType(node.type)
-    );
+    return keywordPrefix + name + ": " + printers.node.printType(node.type);
   }
 
   return (
     keywordPrefix +
-    printers.relationships.namespaceProp(printers.node.printType(node.name)) +
+    name +
     `: any // ${printers.node.printType(node.initializer)}`
   );
 };
@@ -215,17 +218,19 @@ declare ${exporter} var ${nodeName}: {|
 |};\n`;
 };
 
-export const typeReference = (node: RawNode): string => {
+export const typeReference = (node: RawNode, identifier: boolean): string => {
   if (node.typeName.left && node.typeName.right) {
     return (
       printers.node.printType(node.typeName) +
       printers.common.generics(node.typeArguments)
     );
   }
+  const name = identifier
+    ? printers.identifiers.print(node.typeName.text)
+    : node.typeName.text;
   return (
-    printers.relationships.namespaceProp(
-      printers.identifiers.print(node.typeName.text),
-    ) + printers.common.generics(node.typeArguments)
+    printers.relationships.namespaceProp(name) +
+    printers.common.generics(node.typeArguments)
   );
 };
 

--- a/src/printers/identifiers.js
+++ b/src/printers/identifiers.js
@@ -8,6 +8,7 @@ Object.assign(identifiers, {
   Partial: "$Shape",
   Readonly: "$ReadOnly",
   NonNullable: "$NonMaybeType",
+  ReturnType: "$Call",
 });
 
 export const print = (kind: string): string => {

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -254,8 +254,8 @@ export function getTypeofFullyQualifiedName(
       return printEntityName(type);
     }
     if (
-      symbol.parent?.valueDeclaration.kind === ts.SyntaxKind.SourceFile ||
-      (symbol.parent?.valueDeclaration.kind ===
+      symbol.parent?.valueDeclaration?.kind === ts.SyntaxKind.SourceFile ||
+      (symbol.parent?.valueDeclaration?.kind ===
         ts.SyntaxKind.ModuleDeclaration &&
         (symbol.parent?.valueDeclaration.flags & ts.NodeFlags.Namespace) === 0)
     ) {

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -363,7 +363,7 @@ export const printType = (rawType: any): string => {
       const line =
         "Flow doesn't support conditional types, use $Call utility type";
       console.log(line);
-      return `"${line}"`;
+      return `/* ${line} */ any`;
     }
 
     case ts.SyntaxKind.FunctionType:

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -296,6 +296,18 @@ export function getTypeofFullyQualifiedName(
   }
 }
 
+function fixDefaultTypeArguments(symbol, type) {
+  if (!symbol) return
+  if (!symbol.declarations) return
+  const decl = symbol.declarations[0];
+  const allTypeParametersHaveDefaults =
+    !!decl?.typeParameters?.length &&
+    decl.typeParameters.every(param => !!param.default);
+  if (allTypeParametersHaveDefaults && !type.typeArguments) {
+    type.typeArguments = [];
+  }
+}
+
 export const printType = (rawType: any): string => {
   // debuggerif()
   //TODO: #6 No match found in SyntaxKind enum
@@ -449,6 +461,7 @@ export const printType = (rawType: any): string => {
       if (checker.current) {
         //$todo
         const symbol = checker.current.getSymbolAtLocation(type.typeName);
+        fixDefaultTypeArguments(symbol, type);
         renames(symbol, type);
         if (
           symbol &&

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -399,10 +399,18 @@ export const printType = (rawType: any): string => {
       //TODO: replace with boolean %checks when supported in class declarations
       return "boolean";
 
-    case ts.SyntaxKind.IndexedAccessType:
-      return `$ElementType<${printType(type.objectType)}, ${printType(
+    case ts.SyntaxKind.IndexedAccessType: {
+      let fn = "$ElementType";
+      if (
+        type.indexType.kind === ts.SyntaxKind.LiteralType &&
+        type.indexType.literal.kind === ts.SyntaxKind.StringLiteral
+      ) {
+        fn = "$PropertyType";
+      }
+      return `${fn}<${printType(type.objectType)}, ${printType(
         type.indexType,
       )}>`;
+    }
 
     case ts.SyntaxKind.TypeOperator:
       switch (type.operator) {

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -188,7 +188,8 @@ export function getFullyQualifiedName(
         const decl = leftMostSymbol ? leftMostSymbol.declarations[0] : {};
         isExternalSymbol =
           decl.kind === ts.SyntaxKind.NamespaceImport ||
-          decl.kind === ts.SyntaxKind.NamedImports;
+          decl.kind === ts.SyntaxKind.NamedImports ||
+          leftMostSymbol?.parent?.escapedName === "__global";
       }
       if (!symbol || typeChecker.isUnknownSymbol(symbol) || isExternalSymbol) {
         return printEntityName(type);

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -277,7 +277,7 @@ export function getTypeofFullyQualifiedName(
           );
     } else {
       let delimiter = "$";
-      if (symbol.valueDeclaration.kind === ts.SyntaxKind.EnumMember) {
+      if (symbol.valueDeclaration?.kind === ts.SyntaxKind.EnumMember) {
         delimiter = ".";
       }
       return symbol.parent

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -87,7 +87,7 @@ export function printPropertyAccessExpression(
     return (
       printers.relationships.namespace(
         type.expression.kind === ts.SyntaxKind.Identifier
-          ? type.expression.escapedText
+          ? type.expression.text
           : printPropertyAccessExpression(type.expression),
       ) + printPropertyAccessExpression(type.name)
     );
@@ -297,7 +297,7 @@ export function getTypeofFullyQualifiedName(
   }
 }
 
-function fixDefaultTypeArguments(symbol, type) {
+export function fixDefaultTypeArguments(symbol, type) {
   if (!symbol) return
   if (!symbol.declarations) return
   const decl = symbol.declarations[0];
@@ -377,7 +377,7 @@ export const printType = (rawType: any): string => {
     case ts.SyntaxKind.Identifier:
       //case SyntaxKind.StringLiteralType:
       return printers.relationships.namespace(
-        printers.identifiers.print(type.escapedText),
+        printers.identifiers.print(type.text),
         true,
       );
 

--- a/src/printers/smart-identifiers.js
+++ b/src/printers/smart-identifiers.js
@@ -1,0 +1,103 @@
+// @flow
+
+import * as ts from "typescript";
+import {checker} from '../checker'
+
+const setImportedName = (name: string, type, symbol, decl) => {
+  const specifiers = ["react"];
+  const namespaces = ["React"];
+  const paths = (name: string) => {
+    if (name === "react" || name === "React") {
+      return {
+        ReactNode: "Node",
+      };
+    }
+    return {};
+  };
+  if (namespaces.includes(symbol.parent?.escapedName)) {
+    type.escapedText = paths(symbol.parent?.escapedName)[name] || name;
+  } else if (
+    specifiers.includes(decl.parent?.parent?.parent?.moduleSpecifier?.text)
+  ) {
+    type.escapedText =
+      paths(decl.parent.parent.parent.moduleSpecifier.text)[name] || name;
+  }
+};
+const setGlobalName = (type, symbol) => {
+  const globals = [
+    {
+      from: ts.createQualifiedName(ts.createIdentifier("JSX"), "Element"),
+      to: ts.createIdentifier("React$Node"),
+    },
+  ];
+  if (checker.current) {
+    for (const { from, to } of globals) {
+      if (compareQualifiedName(type.typeName, from)) {
+        type.typeName = to;
+      }
+    }
+  }
+};
+
+export function renames(symbol: ts.Symbol | void, type) {
+  if (!symbol) return;
+  if (!symbol.declarations) return;
+  let decl = symbol.declarations[0];
+  if (type.parent.kind === ts.SyntaxKind.NamedImports) {
+    setImportedName(decl.name.escapedText, decl.name, symbol, decl);
+  } else if (type.kind === ts.SyntaxKind.TypeReference) {
+    const leftMost = getLeftMostEntityName(type.typeName);
+    if (leftMost && checker.current) {
+      const leftMostSymbol = checker.current.getSymbolAtLocation(leftMost);
+      const isGlobal = leftMostSymbol?.parent?.escapedName === "__global";
+      if (isGlobal) {
+        setGlobalName(type, symbol);
+        return;
+      }
+    }
+    if (type.typeName.right) {
+      setImportedName(symbol.escapedName, type.typeName.right, symbol, decl);
+    } else {
+      setImportedName(symbol.escapedName, type.typeName, symbol, decl);
+    }
+  }
+}
+
+export function getLeftMostEntityName(type: ts.EntityName) {
+  if (type.kind === ts.SyntaxKind.QualifiedName) {
+    return type.left.kind === ts.SyntaxKind.Identifier
+      ? type.left
+      : getLeftMostEntityName(type.left);
+  } else if (type.kind === ts.SyntaxKind.Identifier) {
+    return type;
+  }
+}
+
+function compareIdentifier(a: ts.Identifier, b: ts.Identifier) {
+  if (a.kind !== b.kind) return false;
+  if (a.escapedText === b.escapedText) return true;
+  return false;
+}
+
+function compareEntityName(a: ts.EntityName, b: ts.EntityName) {
+  if (
+    a.kind === ts.SyntaxKind.Identifier &&
+    b.kind === ts.SyntaxKind.Identifier
+  ) {
+    return compareIdentifier(a, b);
+  }
+  if (
+    a.kind === ts.SyntaxKind.QualifiedName &&
+    b.kind === ts.SyntaxKind.QualifiedName
+  ) {
+    return compareQualifiedName(a, b);
+  }
+  return false;
+}
+
+function compareQualifiedName(a: ts.QualifiedName, b: ts.QualifiedName) {
+  if (a.kind !== b.kind) return false;
+  return (
+    compareEntityName(a.left, b.left) && compareIdentifier(a.right, b.right)
+  );
+}

--- a/src/printers/smart-identifiers.js
+++ b/src/printers/smart-identifiers.js
@@ -75,7 +75,7 @@ export function getLeftMostEntityName(type: ts.EntityName) {
 
 function compareIdentifier(a: ts.Identifier, b: ts.Identifier) {
   if (a.kind !== b.kind) return false;
-  if (a.escapedText === b.escapedText) return true;
+  if (a.escapedText === b.escapedText && a.text === b.text) return true;
   return false;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,10 +2323,10 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flow-bin@^0.92.1:
-  version "0.92.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.92.1.tgz#32c136c07235f30c42dc0549a0790f370fad4070"
-  integrity sha512-F5kC5oQOR2FXROAeybJHFqgZP+moKV9fa/53QK4Q4WayTQHdA0KSl48KD1gP0A9mioRLiKUegTva/7I15cX3Iw==
+flow-bin@^0.94.0:
+  version "0.94.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.94.0.tgz#b5d58fe7559705b73a18229f97edfc3ab6ffffcb"
+  integrity sha512-DYF7r9CJ/AksfmmB4+q+TyLMoeQPRnqtF1Pk7KY3zgfkB/nVuA3nXyzqgsIPIvnMSiFEXQcFK4z+iPxSLckZhQ==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- **JSX.Element to React$Node**
  `JSX.Element` would be converted to `React$Node`

-  **Global augmentation** 
   `declare global` converted to `declare module 'global'`
   Probably should be different name to omit conflicts with modules

- **Omit generic defaults**
   ```ts
   type A<T = number> = {}
   type B = A
   ```
   converted to
   ```ts
   type A<T = number> = {}
   type B = A<>
   ```

- **Conditional type replaced with comment**
   Before this flowgen would convert
   `type S<T> = T extends number ? T : never`
   to
   `type S<T> = "Flow doesn't support conditional types, use $Call utility type"`
   but now it would convert to
   `type S<T> = /* Flow doesn't support conditional types, use $Call utility type */ any`

- **$PropertyType instead of $ElementType if string literal is constant**
  `type S = A["key"]` -> `type S = $PropertyType<A, "key">`
  `type S<T> = A[T]` -> `type S<T> = $ElementType<A, T>`