### PR TITLE
feat(CLI): add `--add-flow-header` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ flowgen lodash.d.ts
 ```
 --flow-typed-format: Format output so it fits in the flow-typed repo
 --compile-tests: Compile any sibling <filename>-tests.ts files found
+--add-flow-header: Add `// @flow` to generated files. Should be used for libs.
 ```
 
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -19,6 +19,10 @@ program
   )
   .option("--no-jsdoc", "output without jsdoc")
   .option("--flow-typed-format [dirname]", "format output for flow-typed")
+  .option(
+    "--add-flow-header",
+    "adds '// @flow' to the generated files (for libs)",
+  )
   .option("--compile-tests", "compile any <filename>-tests.ts files found")
   .arguments("[files...]")
   .action((files, options) => {
@@ -27,6 +31,7 @@ program
       moduleExports: options.moduleExports,
       jsdoc: options.jsdoc,
       flowTypedFormat: options.flowTypedFormat,
+      addFlowHeader: options.addFlowHeader,
       compileTests: options.compileTests,
       out: options.outputFile,
       version: pkg.version,

--- a/src/cli/runner.js
+++ b/src/cli/runner.js
@@ -16,6 +16,7 @@ type RunnerOptions = {
   version: string,
   out: string,
   flowTypedFormat: boolean,
+  addFlowHeader: boolean,
   compileTests: boolean,
 };
 
@@ -39,7 +40,11 @@ export default (options: RunnerOptions) => {
         const outputFile = options.flowTypedFormat ? moduleName : options.out;
 
         // Get the intro text
-        const intro = meta(moduleName, options.version);
+        let intro = meta(moduleName, options.version);
+
+        if (options.addFlowHeader) {
+          intro = `// @flow\n${intro}`;
+        }
 
         // Let the user know what's going on
         if (files.length > 3) {


### PR DESCRIPTION
I'm started using this lib for generating flow definition from typescript files.

Generated flow definitions I put to published lib (without flow-typed), eg https://unpkg.com/mongodb-memory-server@4.0.1/lib/
If I manually add `// @flow` header to all `.flow` files, then they became automatically readable by flow-server and provides proper autocompletion & static checks. Without this header, all imported modules have `any` definition.

I found that better to provide flow definition inside a lib, rather than via flow-typed. Using this approach about 2 years.

This PR adds `--add-flow-header` option for adding `// @flow` header to generated files.

Related issue: https://github.com/joarwilk/flowgen/issues/75