### PR TITLE
Readonly collections, tuples, declare variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ It's surprisingly robust and non-lossy as it stands right now, in big part thank
 | ✅ | Type parameter bounds | `function f<A extends string>(a:A){}` | `function f<A: string>(a:A){}` |
 | ✅ | keyof X | `keyof X` | `$Keys<X>` |
 | ✅ | X[keyof X] | `X[keyof X]` | `$ElementType<X, $Keys<X>>` |
-| ✅ | Partial | `Partial<X>` | `$Shape<X>` |
+| ✅ | Partial | `Partial<X>` | `$Rest<X, {}>` |
 | ✅ | Readonly | `Readonly<X>` | `$ReadOnly<X>` |
 | ✅ | ReadonlyArray | `ReadonlyArray<X>` | `$ReadOnlyArray<X>` |
+| ✅ | ReadonlySet | `ReadonlySet<X>` | `$ReadOnlySet<X>` |
+| ✅ | ReadonlyMap | `ReadonlyMap<X, Y>` | `$ReadOnlyMap<X, Y>` |
 | ✅ | Record | `Record<K, T>` | `{ [key: K]: T }` |
 |    | Pick | `Pick<T, K>` |  |
 |    | Exclude | `Exclude<T, U>` |  |

--- a/src/__tests__/__snapshots__/basic.spec.js.snap
+++ b/src/__tests__/__snapshots__/basic.spec.js.snap
@@ -19,7 +19,9 @@ exports[`should handle basic keywords 1`] = `
   o: empty,
   p: mixed,
   r: -1,
-  s: -2
+  s: -2,
+  t: Symbol,
+  u: Symbol
 };
 "
 `;

--- a/src/__tests__/__snapshots__/namespaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.js.snap
@@ -12,6 +12,11 @@ exports[`should handle global augmentation 1`] = `
 "
 `;
 
+exports[`should handle import equals declaration 1`] = `
+"declare var hello: typeof A.B;
+"
+`;
+
 exports[`should handle namespace function merging 1`] = `
 "declare var test: typeof npm$namespace$test;
 

--- a/src/__tests__/__snapshots__/tuples.spec.js.snap
+++ b/src/__tests__/__snapshots__/tuples.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle tuples 1`] = `
+"declare type T1 = [number, string | void];
+declare type T2 = [number] & string[];
+"
+`;

--- a/src/__tests__/__snapshots__/utility_types.spec.js.snap
+++ b/src/__tests__/__snapshots__/utility_types.spec.js.snap
@@ -4,13 +4,18 @@ exports[`should handle utility types 1`] = `
 "declare type A = $ReadOnly<{
   a: number
 }>;
-declare type B = $Shape<{
-  a: number
-}>;
+declare type B = $Rest<
+  {
+    a: number
+  },
+  {}
+>;
 declare type C = $NonMaybeType<string | null>;
 declare type D = $ReadOnlyArray<string>;
 declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;
 declare type F = { [key: string]: number };
+declare type G = $ReadOnlySet<number>;
+declare type H = $ReadOnlyMap<string, number>;
 declare type A1<Readonly> = Readonly;
 declare type B1<Partial> = Partial;
 declare type C1<NonNullable> = NonNullable;
@@ -18,7 +23,7 @@ declare type D1<ReadonlyArray> = ReadonlyArray;
 declare type E1<ReturnType> = ReturnType;
 declare type F1<Record> = Record;
 declare type A2<T> = $ReadOnly<T>;
-declare type B2<T> = $Shape<T>;
+declare type B2<T> = $Rest<T, {}>;
 declare type C2<T> = $NonMaybeType<T>;
 declare type D2<T> = $ReadOnlyArray<T>;
 declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;

--- a/src/__tests__/__snapshots__/variables.spec.js.snap
+++ b/src/__tests__/__snapshots__/variables.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle declares 1`] = `
+"declare var test: {
+  a: number
+};
+declare var foo: string;
+declare var bar: number;
+declare var baz: number;
+declare var quuz: any;
+declare var quuuz: string;
+declare var quuuuz: number;
+declare var quuuuz: string;
+declare var fox: number;
+"
+`;

--- a/src/__tests__/basic.spec.js
+++ b/src/__tests__/basic.spec.js
@@ -22,6 +22,8 @@ it("should handle basic keywords", () => {
     p: unknown,
     r: -1,
     s: -2,
+    t: symbol,
+    u: unique symbol,
   }`;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();

--- a/src/__tests__/namespaces.spec.js
+++ b/src/__tests__/namespaces.spec.js
@@ -121,3 +121,11 @@ declare global {
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
 });
+
+test("should handle import equals declaration", () => {
+  const ts = `
+import hello = A.B;
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/__tests__/tuples.spec.js
+++ b/src/__tests__/tuples.spec.js
@@ -1,0 +1,12 @@
+// @flow
+
+import { compiler, beautify } from "..";
+
+it("should handle tuples", () => {
+  const ts = `
+  type T1 = [number, string?];
+  type T2 = [number, ...string[]];
+  `;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/__tests__/utility_types.spec.js
+++ b/src/__tests__/utility_types.spec.js
@@ -10,6 +10,8 @@ type C = NonNullable<string | null>
 type D = ReadonlyArray<string>
 type E = ReturnType<() => string>
 type F = Record<string, number>
+type G = ReadonlySet<number>
+type H = ReadonlyMap<string, number>
 
 type A1<Readonly> = Readonly
 type B1<Partial> = Partial

--- a/src/__tests__/variables.spec.js
+++ b/src/__tests__/variables.spec.js
@@ -1,0 +1,18 @@
+// @flow
+
+import { compiler, beautify } from "..";
+
+it("should handle declares", () => {
+  const ts = `
+declare const test: {a: number};
+declare const foo: string, bar: number;
+
+declare var baz: number;
+declare var quuz: any, quuuz: string;
+
+declare let quuuuz: number;
+declare let quuuuz: string, fox: number;
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/printers/declarations.js
+++ b/src/printers/declarations.js
@@ -46,10 +46,11 @@ export const propertyDeclaration = (
 
 export const variableDeclaration = (node: RawNode): string => {
   const declarations = node.declarationList.declarations
-    .map(printers.node.printType)
-    .join(" ");
+    .map(printers.node.printType);
 
-  return `declare ${printers.relationships.exporter(node)}var ${declarations};`;
+  return declarations
+    .map(name => `declare ${printers.relationships.exporter(node)}var ${name};`)
+    .join("\n");
 };
 
 export const interfaceType = (

--- a/src/printers/identifiers.js
+++ b/src/printers/identifiers.js
@@ -7,7 +7,8 @@ import printers from "./index";
 const identifiers = Object.create(null);
 Object.assign(identifiers, {
   ReadonlyArray: "$ReadOnlyArray",
-  Partial: "$Shape",
+  ReadonlySet: "$ReadOnlySet",
+  ReadonlyMap: "$ReadOnlyMap",
   Readonly: "$ReadOnly",
   NonNullable: "$NonMaybeType",
   ReturnType: (typeArguments: any[]) => {

--- a/src/printers/identifiers.js
+++ b/src/printers/identifiers.js
@@ -11,6 +11,9 @@ Object.assign(identifiers, {
   ReadonlyMap: "$ReadOnlyMap",
   Readonly: "$ReadOnly",
   NonNullable: "$NonMaybeType",
+  Partial: ([type]: any[]) => {
+    return `$Rest<${printers.node.printType(type)}, {}>`;
+  },
   ReturnType: (typeArguments: any[]) => {
     return `$Call<<R>((...args: any[]) => R) => R, ${printers.node.printType(
       typeArguments[0],


### PR DESCRIPTION
- Add `$ReadOnlySet` and `$ReadOnlyMap`
- Replace `$Shape<T>` with `$Rest<T, {}>`
- Convert `[number, string?]` to `[number, string | void]`
- Convert `[number, ...string[]]` to `[number] & string[]`
- Convert 
```js
declare var foo: number, baz: string;
```
to 
```js
declare var foo: number; declare var baz: string;
```