### PR TITLE
Error messages, JSDoc types, computed properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     ]
   },
   "dependencies": {
+    "@babel/code-frame": "^7.0.0",
+    "@babel/highlight": "^7.0.0",
     "commander": "^2.11.0",
     "lodash": "^4.17.4",
     "paralleljs": "^0.2.1",
@@ -49,7 +51,8 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jest": "^22.2.2",
     "flow-bin": "^0.95.0",
-    "jest": "^24.5.0"
+    "jest": "^24.5.0",
+    "recast": "^0.18.1"
   },
   "files": [
     "lib",

--- a/src/__tests__/__snapshots__/classes.spec.js.snap
+++ b/src/__tests__/__snapshots__/classes.spec.js.snap
@@ -6,6 +6,15 @@ exports[`should handle static methods ES6 classes 1`] = `
   static create: Function;
   lift<R>(operator: Operator<T, R>): Observable<R>;
   static lift<R>(operator: Operator<T, R>): Observable<R>;
+  +foo: number;
+  static +bar: string;
+  baz?: string;
+  +quux?: number;
+  static quick?: Symbol;
+  static +fox?: string;
+  jump?: () => void;
+  +jump?: () => void;
+  static +jump?: () => void;
 }
 "
 `;

--- a/src/__tests__/__snapshots__/computed.spec.js.snap
+++ b/src/__tests__/__snapshots__/computed.spec.js.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should approximate unsupported keys 1`] = `
+"declare type A = {
+  [typeof Foo]: (() => any) | void,
+  +[typeof Foo]: (() => any) | void,
+  [typeof Foo]: () => any,
+  +[typeof Foo]: () => any,
+  [typeof Foo]: any | void,
+  +[typeof Foo]: any | void,
+  [typeof Foo]: any,
+  +[typeof Foo]: any
+};
+declare class B {
+  [typeof Foo]: (() => any) | void;
+  +[typeof Foo]: (() => any) | void;
+  [typeof Foo]: () => any;
+  +[typeof Foo]: () => any;
+  [typeof Foo]: any | void;
+  +[typeof Foo]: any | void;
+  [typeof Foo]: any;
+  +[typeof Foo]: any;
+}
+declare interface C {
+  [typeof Foo]: (() => any) | void;
+  +[typeof Foo]: (() => any) | void;
+  [typeof Foo]: () => any;
+  +[typeof Foo]: () => any;
+  [typeof Foo]: any | void;
+  +[typeof Foo]: any | void;
+  [typeof Foo]: any;
+  +[typeof Foo]: any;
+}
+"
+`;
+
+exports[`should handle computed Symbol.iterator and Symbol.asyncIterator 1`] = `
+"declare type A = {
+  @@asyncIterator: (() => any) | void,
+  @@iterator: (() => any) | void,
+  +@@asyncIterator: (() => any) | void,
+  +@@iterator: (() => any) | void,
+  @@asyncIterator: () => any,
+  @@iterator: () => any,
+  +@@asyncIterator: () => any,
+  +@@iterator: () => any,
+  @@asyncIterator: any | void,
+  @@iterator: any | void,
+  +@@asyncIterator: any | void,
+  +@@iterator: any | void,
+  @@asyncIterator: any,
+  @@iterator: any,
+  +@@asyncIterator: any,
+  +@@iterator: any
+};
+declare class B {
+  @@asyncIterator: (() => any) | void;
+  @@iterator: (() => any) | void;
+  +@@asyncIterator: (() => any) | void;
+  +@@iterator: (() => any) | void;
+  @@asyncIterator: () => any;
+  @@iterator: () => any;
+  +@@asyncIterator: () => any;
+  +@@iterator: () => any;
+  @@asyncIterator: any | void;
+  @@iterator: any | void;
+  +@@asyncIterator: any | void;
+  +@@iterator: any | void;
+  @@asyncIterator: any;
+  @@iterator: any;
+  +@@asyncIterator: any;
+  +@@iterator: any;
+}
+declare interface C {
+  @@asyncIterator: (() => any) | void;
+  @@iterator: (() => any) | void;
+  +@@asyncIterator: (() => any) | void;
+  +@@iterator: (() => any) | void;
+  @@asyncIterator: () => any;
+  @@iterator: () => any;
+  +@@asyncIterator: () => any;
+  +@@iterator: () => any;
+  @@asyncIterator: any | void;
+  @@iterator: any | void;
+  +@@asyncIterator: any | void;
+  +@@iterator: any | void;
+  @@asyncIterator: any;
+  @@iterator: any;
+  +@@asyncIterator: any;
+  +@@iterator: any;
+}
+"
+`;
+
+exports[`should handle string literals 1`] = `
+"declare type A = {
+  foo: (() => any) | void,
+  +foo: (() => any) | void,
+  foo: () => any,
+  +foo: () => any,
+  foo: any | void,
+  +foo: any | void,
+  foo: any,
+  +foo: any
+};
+declare class B {
+  foo: (() => any) | void;
+  +foo: (() => any) | void;
+  foo: () => any;
+  +foo: () => any;
+  foo: any | void;
+  +foo: any | void;
+  foo: any;
+  +foo: any;
+}
+declare interface C {
+  foo: (() => any) | void;
+  +foo: (() => any) | void;
+  foo: () => any;
+  +foo: () => any;
+  foo: any | void;
+  +foo: any | void;
+  foo: any;
+  +foo: any;
+}
+"
+`;

--- a/src/__tests__/__snapshots__/interfaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.js.snap
@@ -71,6 +71,15 @@ exports[`should handle toString property name 1`] = `
 "
 `;
 
+exports[`should handle typed array binding pattern 1`] = `
+"declare interface ArrayBinding {
+  (): void;
+  (x: []): void;
+  (x: [string, number]): void;
+}
+"
+`;
+
 exports[`should handle typed object binding pattern 1`] = `
 "declare interface ObjectBinding {
   (): void;
@@ -79,6 +88,15 @@ exports[`should handle typed object binding pattern 1`] = `
     a: string,
     b: number
   }): void;
+}
+"
+`;
+
+exports[`should handle untyped array binding pattern 1`] = `
+"declare interface ArrayBinding {
+  (): void;
+  (x: any): void;
+  (x: any): void;
 }
 "
 `;

--- a/src/__tests__/__snapshots__/jsdoc.spec.js.snap
+++ b/src/__tests__/__snapshots__/jsdoc.spec.js.snap
@@ -9,6 +9,76 @@ exports[`should handle basic jsdoc 1`] = `
 declare function authorize(userToken: string): Promise<void>;
 
 /**
+ * @param {*} any_type
+ * @returns {void}
+ */
+declare function untyped(any_type: any): void;
+declare type F = {
+  /**
+   * Get instance or instances of type registered under the provided name and optional hint.
+   * @param {string} name The binding name.
+   * @param {string} hint The binding hint.
+   * @param {...args} args Additional args.
+   */
+  get<T>(name: string, hint?: string, ...args: any[]): T,
+
+  /**
+   * This method inserts an entry to the list. Optionally it can place new entry at provided index.
+   * @param {?} entry - The entry to insert
+   * @param {number=} opt_idx - The index where the new entry should be inserted; if omitted or greater then the current size of the list, the entry is added at the end of the list;
+   * a negative index is treated as being relative from the end of the list
+   */
+  add(entry: any, opt_idx?: number): void
+};
+/**
+ * Patches an Element with the the provided function. Exactly one top level
+ * element call should be made corresponding to \`node\`.
+ * @param {!Element} node The Element where the patch should start.
+ * @param {!function(T)} fn A function containing open/close/etc. calls that
+ * describe the DOM. This should have at most one top level element call.
+ * @param {T=} data An argument passed to fn to represent DOM state.
+ * @return {?Node} The node if it was updated, its replacedment or null if it
+ * was removed.
+ * @template
+ */
+declare var patchOuter: <T>(
+  node: Element,
+  fn: (data: T) => void,
+  data?: T
+) => Node | null;
+/**
+ * Creates an ECharts instance, and returns an echartsInstance. You shall
+ *      not initialize multiple ECharts instances on a single container.
+ * @param {HTMLDivElement | HTMLCanvasElement} dom Instance container,
+ * usually is a \`div\` element with height and width defined.
+ * @param {{[key: string]: any} | string} [theme] Theme to be applied.
+ * This can be a configuring object of a theme, or a theme name
+ * registered through [echarts.registerTheme](https://echarts.apache.org/api.html#echarts.registerTheme).
+ * @param {object} [opts] Chart configurations.
+ * @param {number} [opts.devicePixelRatio] Ratio of one physical pixel to
+ * the size of one device independent pixels. Browser's
+ * \`window.devicePixelRatio\` is used by default.
+ * @param {string} [opts.renderer] Supports \`'canvas'\` or \`'svg'\`.
+ * See [Render by Canvas or SVG](https://echarts.apache.org/tutorial.html#Render%20by%20Canvas%20or%20SVG).
+ * @param {number} [opts.width] Specify width explicitly, in pixel.
+ * If setting to \`null\`/\`undefined\`/\`'auto'\`, width of \`dom\`
+ * (instance container) will be used.
+ * @param {number} [opts.height] Specify height explicitly, in pixel.
+ * If setting to \`null\`/\`undefined\`/\`'auto'\`, height of \`dom\`
+ * (instance container) will be used.
+ */
+declare function init(
+  dom: HTMLDivElement | HTMLCanvasElement,
+  theme?: { [key: string]: any } | string,
+  opts?: {
+    devicePixelRatio?: number,
+    renderer?: string,
+    width?: number | string,
+    height?: number | string
+  }
+): ECharts;
+
+/**
  * Plain comment
  */
 declare function test(): Promise<void>;

--- a/src/__tests__/basic.spec.js
+++ b/src/__tests__/basic.spec.js
@@ -25,6 +25,6 @@ it("should handle basic keywords", () => {
     t: symbol,
     u: unique symbol,
   }`;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/boolean_literals.spec.js
+++ b/src/__tests__/boolean_literals.spec.js
@@ -8,7 +8,7 @@ it("should handle boolean literals in type", () => {
   type MyTruthyType = true | string;
 `;
 
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
 
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/classes.spec.js
+++ b/src/__tests__/classes.spec.js
@@ -8,7 +8,16 @@ it("should handle static methods ES6 classes", () => {
     static create: Function;
     lift<R>(operator: Operator<T, R>): Observable<R>;
     static lift<R>(operator: Operator<T, R>): Observable<R>;
+    readonly foo: number;
+    static readonly bar: string;
+    baz?: string;
+    readonly quux?: number;
+    static quick?: symbol;
+    static readonly fox?: string;
+    jump?(): void;
+    readonly jump?(): void;
+    static readonly jump?(): void;
   }`;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/computed.spec.js
+++ b/src/__tests__/computed.spec.js
@@ -1,0 +1,144 @@
+// @flow
+
+import { compiler, beautify } from "..";
+
+it("should handle computed Symbol.iterator and Symbol.asyncIterator", () => {
+  const ts = `
+  type A = {
+    [Symbol.asyncIterator]?(): any,
+    [Symbol.iterator]?(): any,
+    readonly [Symbol.asyncIterator]?(): any,
+    readonly [Symbol.iterator]?(): any,
+    [Symbol.asyncIterator](): any,
+    [Symbol.iterator](): any,
+    readonly [Symbol.asyncIterator](): any,
+    readonly [Symbol.iterator](): any,
+    [Symbol.asyncIterator]?: any,
+    [Symbol.iterator]?: any,
+    readonly [Symbol.asyncIterator]?: any,
+    readonly [Symbol.iterator]?: any,
+    [Symbol.asyncIterator]: any,
+    [Symbol.iterator]: any,
+    readonly [Symbol.asyncIterator]: any,
+    readonly [Symbol.iterator]: any,
+  }
+  declare class B {
+    [Symbol.asyncIterator]?(): any,
+    [Symbol.iterator]?(): any,
+    readonly [Symbol.asyncIterator]?(): any,
+    readonly [Symbol.iterator]?(): any,
+    [Symbol.asyncIterator](): any,
+    [Symbol.iterator](): any,
+    readonly [Symbol.asyncIterator](): any,
+    readonly [Symbol.iterator](): any,
+    [Symbol.asyncIterator]?: any,
+    [Symbol.iterator]?: any,
+    readonly [Symbol.asyncIterator]?: any,
+    readonly [Symbol.iterator]?: any,
+    [Symbol.asyncIterator]: any,
+    [Symbol.iterator]: any,
+    readonly [Symbol.asyncIterator]: any,
+    readonly [Symbol.iterator]: any,
+  }
+  interface C {
+    [Symbol.asyncIterator]?(): any,
+    [Symbol.iterator]?(): any,
+    readonly [Symbol.asyncIterator]?(): any,
+    readonly [Symbol.iterator]?(): any,
+    [Symbol.asyncIterator](): any,
+    [Symbol.iterator](): any,
+    readonly [Symbol.asyncIterator](): any,
+    readonly [Symbol.iterator](): any,
+    [Symbol.asyncIterator]?: any,
+    [Symbol.iterator]?: any,
+    readonly [Symbol.asyncIterator]?: any,
+    readonly [Symbol.iterator]?: any,
+    [Symbol.asyncIterator]: any,
+    [Symbol.iterator]: any,
+    readonly [Symbol.asyncIterator]: any,
+    readonly [Symbol.iterator]: any,
+  }
+`;
+
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
+
+  expect(beautify(result)).toMatchSnapshot();
+});
+
+it("should handle string literals", () => {
+  const ts = `
+  type A = {
+    ["foo"]?(): any,
+    readonly ["foo"]?(): any,
+    ["foo"](): any,
+    readonly ["foo"](): any,
+    ["foo"]?: any,
+    readonly ["foo"]?: any,
+    ["foo"]: any,
+    readonly ["foo"]: any,
+  }
+  declare class B {
+    ["foo"]?(): any,
+    readonly ["foo"]?(): any,
+    ["foo"](): any,
+    readonly ["foo"](): any,
+    ["foo"]?: any,
+    readonly ["foo"]?: any,
+    ["foo"]: any,
+    readonly ["foo"]: any,
+  }
+  interface C {
+    ["foo"]?(): any,
+    readonly ["foo"]?(): any,
+    ["foo"](): any,
+    readonly ["foo"](): any,
+    ["foo"]?: any,
+    readonly ["foo"]?: any,
+    ["foo"]: any,
+    readonly ["foo"]: any,
+  }
+`;
+
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
+
+  expect(beautify(result)).toMatchSnapshot();
+});
+
+it("should approximate unsupported keys", () => {
+  const ts = `
+  type A = {
+    [Foo]?(): any,
+    readonly [Foo]?(): any,
+    [Foo](): any,
+    readonly [Foo](): any,
+    [Foo]?: any,
+    readonly [Foo]?: any,
+    [Foo]: any,
+    readonly [Foo]: any,
+  }
+  declare class B {
+    [Foo]?(): any,
+    readonly [Foo]?(): any,
+    [Foo](): any,
+    readonly [Foo](): any,
+    [Foo]?: any,
+    readonly [Foo]?: any,
+    [Foo]: any,
+    readonly [Foo]: any,
+  }
+  interface C {
+    [Foo]?(): any,
+    readonly [Foo]?(): any,
+    [Foo](): any,
+    readonly [Foo](): any,
+    [Foo]?: any,
+    readonly [Foo]?: any,
+    [Foo]: any,
+    readonly [Foo]: any,
+  }
+`;
+
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
+
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/__tests__/enums.spec.js
+++ b/src/__tests__/enums.spec.js
@@ -4,7 +4,7 @@ import { compiler, beautify } from "..";
 
 it("should handle empty enums", () => {
   const ts = `enum Empty { }`;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot("class");
 });
 
@@ -17,7 +17,7 @@ it("should handle basic enums", () => {
 type A = Label
 type B = Label.LABEL_OPTIONAL
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot("class");
 });
 
@@ -32,7 +32,7 @@ it("should handle number enums", () => {
 type A = Label
 type B = Label.TWO
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot("class");
 });
 
@@ -45,6 +45,6 @@ it("should handle string enums", () => {
 type A = Label
 type B = Label.LABEL_REQUIRED
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot("class");
 });

--- a/src/__tests__/exports.spec.js
+++ b/src/__tests__/exports.spec.js
@@ -14,7 +14,7 @@ export * from 'typescript';
 //export traverse, { Visitor, NodePath } from "@babel/traverse";
 //export template from "@babel/template";
 //export * as t from "@babel/types";`;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -22,6 +22,6 @@ test("should handle unnamed default export", () => {
   const ts = `
 export default function(): void;
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/function_exports.spec.js
+++ b/src/__tests__/function_exports.spec.js
@@ -6,7 +6,7 @@ it("should handle exported es module functions", () => {
   const ts = `export function routerReducer(state?: RouterState, action?: Action): RouterState;
 export function syncHistoryWithStore(history: History, store: Store<any>, options?: SyncHistoryWithStoreOptions): History & HistoryUnsubscribe;
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -15,13 +15,13 @@ it("should handle toString function overload", () => {
 export function toString(e: number): void;
 export function toString(b: string): void;
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
 it("should handle default exported es module functions", () => {
   const ts = `export default function routerReducer(state?: RouterState, action?: Action): RouterState;`;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -29,20 +29,20 @@ it("should handle function overload es module functions", () => {
   const ts = `export function routerReducer(state?: RouterState, action?: Action): RouterState;
 export function routerReducer(state?: RouterState): RouterState;
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
 it("should remove this annotation from functions", () => {
   const ts =
     "function addClickListener(onclick: (this: void, e: Event) => void): void;";
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
 it("should remove default parameters from functions", () => {
   const ts =
     "function addClickListener<T = Error>(onclick: (e: Event) => void): T;";
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/global_declares.spec.js
+++ b/src/__tests__/global_declares.spec.js
@@ -9,5 +9,5 @@ declare interface ICustomMessage {
   otherMethod(literal: "A"|"B"): void;
 }
 `;
-  expect(beautify(compiler.compileDefinitionString(ts))).toMatchSnapshot();
+  expect(beautify(compiler.compileDefinitionString(ts, {quiet: true}))).toMatchSnapshot();
 });

--- a/src/__tests__/imports.spec.js
+++ b/src/__tests__/imports.spec.js
@@ -9,7 +9,7 @@ import { Visitor as NewVisitor } from "@babel/traverse";
 import template from "@babel/template";
 import * as t from "@babel/types";
 import v, * as d from 'typescript';`;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -24,7 +24,7 @@ declare module '@babel/core' {
   import v, * as d from 'typescript';
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -32,6 +32,6 @@ it("should handle import type", () => {
   const ts = `
 type S = typeof import('http')
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/interface_exports.spec.js
+++ b/src/__tests__/interface_exports.spec.js
@@ -7,5 +7,5 @@ it("should handle exported interfaces", () => {
     (source: T): R;
   }
 `;
-  expect(beautify(compiler.compileDefinitionString(ts))).toMatchSnapshot();
+  expect(beautify(compiler.compileDefinitionString(ts, {quiet: true}))).toMatchSnapshot();
 });

--- a/src/__tests__/interfaces.spec.js
+++ b/src/__tests__/interfaces.spec.js
@@ -168,12 +168,36 @@ interface ObjectBinding {
   expect(beautify(result)).toMatchSnapshot();
 });
 
+it("should handle untyped array binding pattern", () => {
+  const ts = `
+interface ArrayBinding {
+  (): void;
+  ([]): void;
+  ([ a, b ]): void;
+}
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});
+
 it("should handle typed object binding pattern", () => {
   const ts = `
 interface ObjectBinding {
   (): void;
   ({}: any): void;
   ({ a, b }: { a: string, b: number }): void;
+}
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+});
+
+it("should handle typed array binding pattern", () => {
+  const ts = `
+interface ArrayBinding {
+  (): void;
+  ([]: []): void;
+  ([ a, b ]: [string, number]): void;
 }
 `;
   const result = compiler.compileDefinitionString(ts);

--- a/src/__tests__/jsdoc.spec.js
+++ b/src/__tests__/jsdoc.spec.js
@@ -11,11 +11,84 @@ it("should handle basic jsdoc", () => {
 declare function authorize(userToken: string): Promise<void>
 
 /**
+ * @param {*} any_type
+ * @returns {void}
+ */
+declare function untyped(any_type: any): void;
+
+type F = {
+  /**
+   * Get instance or instances of type registered under the provided name and optional hint.
+   * @param {string} name The binding name.
+   * @param {string} hint The binding hint.
+   * @param {...args} args Additional args.
+   */
+  get<T>(name: string, hint?: string, ...args: any[]): T;
+  /**
+   * This method inserts an entry to the list. Optionally it can place new entry at provided index.
+   * @param entry {?} - The entry to insert
+   * @param opt_idx {number=} - The index where the new entry should be inserted; if omitted or greater then the current size of the list, the entry is added at the end of the list;
+   * a negative index is treated as being relative from the end of the list
+   */
+  add(entry: any, opt_idx?: number): void;
+}
+
+/**
+ * Patches an Element with the the provided function. Exactly one top level
+ * element call should be made corresponding to \`node\`.
+ * @param {!Element} node The Element where the patch should start.
+ * @param {!function(T)} fn A function containing open/close/etc. calls that
+ *     describe the DOM. This should have at most one top level element call.
+ * @param {T=} data An argument passed to fn to represent DOM state.
+ * @return {?Node} The node if it was updated, its replacedment or null if it
+ *     was removed.
+ * @template T
+ */
+declare var patchOuter: <T>(
+  node: Element,
+  fn: (data: T) => void,
+  data?: T,
+) => Node | null;
+
+/**
+ * Creates an ECharts instance, and returns an echartsInstance. You shall
+ *     not initialize multiple ECharts instances on a single container.
+ *
+ * @param {HTMLDivElement | HTMLCanvasElement} dom Instance container,
+ *     usually is a \`div\` element with height and width defined.
+ * @param {object | string} [theme] Theme to be applied.
+ *     This can be a configuring object of a theme, or a theme name
+ *     registered through [echarts.registerTheme](https://echarts.apache.org/api.html#echarts.registerTheme).
+ * @param {object} [opts] Chart configurations.
+ * @param {number} [opts.devicePixelRatio] Ratio of one physical pixel to
+ *     the size of one device independent pixels. Browser's
+ *     \`window.devicePixelRatio\` is used by default.
+ * @param {string} [opts.renderer] Supports \`'canvas'\` or \`'svg'\`.
+ *     See [Render by Canvas or SVG](https://echarts.apache.org/tutorial.html#Render%20by%20Canvas%20or%20SVG).
+ * @param {number} [opts.width] Specify width explicitly, in pixel.
+ *     If setting to \`null\`/\`undefined\`/\`'auto'\`, width of \`dom\`
+ *     (instance container) will be used.
+ * @param {number} [opts.height] Specify height explicitly, in pixel.
+ *     If setting to \`null\`/\`undefined\`/\`'auto'\`, height of \`dom\`
+ *     (instance container) will be used.
+ */
+function init(
+  dom: HTMLDivElement | HTMLCanvasElement,
+  theme?: object | string,
+  opts?: {
+    devicePixelRatio?: number;
+    renderer?: string;
+    width?: number | string;
+    height?: number | string;
+  },
+): ECharts;
+
+/**
  * Plain comment
  */
 declare function test(): Promise<void>
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -27,6 +100,6 @@ it("should remove jsdoc", () => {
  */
 declare function authorize(userToken: string): Promise<void>
 `;
-  const result = compiler.compileDefinitionString(ts, { jsdoc: false });
+  const result = compiler.compileDefinitionString(ts, { quiet: true, jsdoc: false });
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/mapped_types.spec.js
+++ b/src/__tests__/mapped_types.spec.js
@@ -18,6 +18,6 @@ type MappedObj = {
 }
 type ConstantKey = MappedObj["a"]
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/module_identifiers.spec.js
+++ b/src/__tests__/module_identifiers.spec.js
@@ -9,7 +9,7 @@ import * as React from 'react'
 declare function s(node: ReactNode): void;
 declare function s(node: React.ReactNode): void;
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -25,7 +25,7 @@ declare class Component extends React.Component<Props> {
   render(): JSX.Element
 }
 `;
-    const result = compiler.compileDefinitionString(ts);
+    const result = compiler.compileDefinitionString(ts, {quiet: true});
     expect(beautify(result)).toMatchSnapshot();
   });
 });

--- a/src/__tests__/modules.spec.js
+++ b/src/__tests__/modules.spec.js
@@ -13,7 +13,7 @@ declare module 'test' {
   export const ok: number
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -32,7 +32,7 @@ declare module 'test' {
   export const error: string
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -52,7 +52,7 @@ export interface A {
   bar: string
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -65,6 +65,6 @@ declare module 'test' {
   declare function test(response: string): string
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/namespaces.spec.js
+++ b/src/__tests__/namespaces.spec.js
@@ -8,7 +8,7 @@ namespace test {
   export const ok: number
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -21,7 +21,7 @@ namespace test {
   export const error: string
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -34,7 +34,7 @@ namespace test {
   declare function test(response: string): string
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -44,7 +44,7 @@ namespace Example {
   export interface StoreModel<S> {}
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -90,7 +90,7 @@ declare namespace E0 {
   declare var s1: string;
 }
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -103,13 +103,13 @@ declare namespace A.B {
   }
   declare class D<S> {}
 }
-  
+
 declare namespace A.B.C {
   declare class N<A> extends D<A> implements S<A> {
     a: string;
   }
 }`;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -118,7 +118,7 @@ test("should handle global augmentation", () => {
 declare global {
   interface Array<T> {}
 }`;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -126,6 +126,6 @@ test("should handle import equals declaration", () => {
   const ts = `
 import hello = A.B;
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/string_literals.spec.js
+++ b/src/__tests__/string_literals.spec.js
@@ -15,7 +15,7 @@ it("should handle string literals in function argument \"overloading\"", () => {
   }
 `;
 
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
 
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/tuples.spec.js
+++ b/src/__tests__/tuples.spec.js
@@ -7,6 +7,6 @@ it("should handle tuples", () => {
   type T1 = [number, string?];
   type T2 = [number, ...string[]];
   `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/type_exports.spec.js
+++ b/src/__tests__/type_exports.spec.js
@@ -7,5 +7,5 @@ it("should handle exported types", () => {
 export declare type FactoryOrValue<T> = T | (() => T);
 export type Maybe<T> = {type: 'just', value: T} | {type: 'nothing'}
 `;
-  expect(beautify(compiler.compileDefinitionString(ts))).toMatchSnapshot();
+  expect(beautify(compiler.compileDefinitionString(ts, {quiet: true}))).toMatchSnapshot();
 });

--- a/src/__tests__/union_strings.spec.js
+++ b/src/__tests__/union_strings.spec.js
@@ -10,7 +10,7 @@ it("should handle union strings", () => {
   type CompletionsTriggerCharacter = '"' | "'";
 `;
 
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
 
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/utility_types.spec.js
+++ b/src/__tests__/utility_types.spec.js
@@ -27,6 +27,6 @@ type D2<T> = ReadonlyArray<T>
 type E2<T> = ReturnType<() => T>
 type F2<T, U> = Record<T, U>
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/value_exports.spec.js
+++ b/src/__tests__/value_exports.spec.js
@@ -6,7 +6,7 @@ it("should handle exported es module values", () => {
   const ts = `declare var test: {a: number};
 export {test};
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });
 
@@ -14,6 +14,6 @@ it("should handle default exported es module values", () => {
   const ts = `declare var test: {a: number};
 export default test;
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/__tests__/variables.spec.js
+++ b/src/__tests__/variables.spec.js
@@ -13,6 +13,6 @@ declare var quuz: any, quuuz: string;
 declare let quuuuz: number;
 declare let quuuuz: string, fox: number;
 `;
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
   expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/cli/__tests__/compiler.spec.js
+++ b/src/cli/__tests__/compiler.spec.js
@@ -4,6 +4,7 @@ import compiler from "../compiler";
 it("should handle maybe & nullable type", () => {
   const result = compiler.compileDefinitionString(
     "let a: string | null | undefined",
+    {quiet: true}
   );
 
   expect(result).toMatchSnapshot();
@@ -17,7 +18,7 @@ it("should handle bounded polymorphism", () => {
     }
   `;
 
-  const result = compiler.compileDefinitionString(ts);
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
 
   expect(result).toMatchSnapshot();
 });

--- a/src/cli/__tests__/fixtures.spec.js
+++ b/src/cli/__tests__/fixtures.spec.js
@@ -7,7 +7,7 @@ it("handles the danger.d.ts correctly", () => {
     `${__dirname}/fixtures/danger.d.ts`,
     "utf8",
   );
-  const result = compiler.compileDefinitionString(dangerDTS);
+  const result = compiler.compileDefinitionString(dangerDTS, {quiet: true});
 
   expect(result).toMatchSnapshot();
 });

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -17,6 +17,7 @@ program
     "--interface-records",
     "exact records instead of interfaces in output",
   )
+  .option("--quiet", "output without logs")
   .option("--no-jsdoc", "output without jsdoc")
   .option("--flow-typed-format [dirname]", "format output for flow-typed")
   .option(
@@ -30,6 +31,7 @@ program
       interfaceRecords: options.interfaceRecords,
       moduleExports: options.moduleExports,
       jsdoc: options.jsdoc,
+      quiet: options.quiet,
       flowTypedFormat: options.flowTypedFormat,
       addFlowHeader: options.addFlowHeader,
       compileTests: options.compileTests,

--- a/src/cli/runner.js
+++ b/src/cli/runner.js
@@ -13,6 +13,7 @@ import flowTypedExporter from "./flow-typed-exporter";
 
 type RunnerOptions = {
   jsdoc: boolean,
+  quiet: boolean,
   interfaceRecords: boolean,
   moduleExports: boolean,
   version: string,
@@ -128,6 +129,7 @@ export default (options: RunnerOptions) => {
           files.map(v => v.file),
           {
             jsdoc: options.jsdoc,
+            quiet: options.quiet,
             interfaceRecords: options.interfaceRecords,
             moduleExports: options.moduleExports,
           },
@@ -152,6 +154,7 @@ export default (options: RunnerOptions) => {
         const file = files[0];
         const flowDefinitions = compiler.compileDefinitionFile(file.file, {
           jsdoc: options.jsdoc,
+          quiet: options.quiet,
           interfaceRecords: options.interfaceRecords,
           moduleExports: options.moduleExports,
         });

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,20 @@
+//@flow
+
+let i = 0;
+let envs = {};
+
+export function withEnv<Env, A: $ReadOnlyArray<any>, B>(
+  callback: (env: Env, ...args: A) => B,
+): (...args: A) => B {
+  function fn(...args) {
+    return callback(envs[i - 1], ...args);
+  }
+  fn.withEnv = env => {
+    envs[i] = env;
+    i++;
+    return (...args) => {
+      return callback(env, ...args);
+    };
+  };
+  return fn;
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,58 @@
+//@flow
+
+import type { SourceFile } from "typescript";
+import { opts } from "./options";
+import path from "path";
+import { codeFrameColumns } from "@babel/code-frame";
+import { getChalk } from "@babel/highlight";
+
+const sourceFile: { current: SourceFile | null } = { current: null };
+
+export function setSourceFile(file: SourceFile) {
+  sourceFile.current = file;
+}
+
+export function error(node: any, message: string) {
+  if (opts().quiet) return;
+  if (sourceFile.current) {
+    const options = {
+      highlightCode: true,
+      message,
+    };
+    const chalk = getChalk(options);
+    const code = sourceFile.current.text;
+    const tsStartLocation = sourceFile.current.getLineAndCharacterOfPosition(
+      node.getStart(sourceFile.current),
+    );
+    const tsEndLocation = sourceFile.current.getLineAndCharacterOfPosition(
+      node.getEnd(),
+    );
+    const babelLocation = {
+      start: {
+        line: tsStartLocation.line + 1,
+        column: tsStartLocation.character + 1,
+      },
+      end: {
+        line: tsEndLocation.line + 1,
+        column: tsEndLocation.character + 1,
+      },
+    };
+    const result = codeFrameColumns(code, babelLocation, options);
+    const position = `:${babelLocation.start.line}:${
+      babelLocation.start.column
+    }`;
+    const fileName = path.relative(process.cwd(), sourceFile.current.fileName);
+    console.log(
+      chalk.red.bold(
+        `Error ${"-".repeat(
+          process.stdout.columns - 7 - fileName.length - position.length,
+        )} ${fileName}${position}`,
+      ),
+    );
+    console.log("\n");
+    console.log(result);
+    console.log("\n");
+  } else {
+    console.log(message);
+  }
+}

--- a/src/options.js
+++ b/src/options.js
@@ -4,12 +4,14 @@ export type Options = {|
   jsdoc?: boolean,
   interfaceRecords?: boolean,
   moduleExports?: boolean,
+  quiet?: boolean,
 |};
 
 const defaultOptions: Options = Object.freeze({
   jsdoc: true,
   interfaceRecords: false,
   moduleExports: true,
+  quiet: false,
 });
 
 let options: Options = { ...defaultOptions };

--- a/src/printers/common.js
+++ b/src/printers/common.js
@@ -46,7 +46,10 @@ export const parameter = (param: RawNode): string => {
   }
   let right;
 
-  if (param.name.kind === ts.SyntaxKind.ObjectBindingPattern) {
+  if (
+    param.name.kind === ts.SyntaxKind.ObjectBindingPattern ||
+    param.name.kind === ts.SyntaxKind.ArrayBindingPattern
+  ) {
     left = `x`;
   } else {
     left += printers.node.printType(param.name);

--- a/src/printers/common.js
+++ b/src/printers/common.js
@@ -68,8 +68,15 @@ export const parameter = (param: RawNode): string => {
     right = printers.node.printType(param.type);
   }
 
-  if (param.questionToken) {
+  if (param.questionToken && param.name.kind !== ts.SyntaxKind.ComputedPropertyName) {
     left += "?";
+  }
+
+  if (
+    param.questionToken &&
+    param.name.kind === ts.SyntaxKind.ComputedPropertyName
+  ) {
+    right = `(${right}) | void`;
   }
 
   if (param.dotDotDotToken) {
@@ -93,12 +100,25 @@ export const methodSignature = (param: RawNode) => {
   left += printers.node.printType(param.name);
   let right;
 
-  if (param.questionToken) {
+  if (
+    param.questionToken &&
+    param.name.kind !== ts.SyntaxKind.ComputedPropertyName
+  ) {
     left += "?";
+    isMethod = false;
+  }
+  if (param.name.kind === ts.SyntaxKind.ComputedPropertyName) {
     isMethod = false;
   }
 
   right = printers.functions.functionType(param, isMethod);
+
+  if (
+    param.questionToken &&
+    param.name.kind === ts.SyntaxKind.ComputedPropertyName
+  ) {
+    right = `(${right}) | void`;
+  }
 
   return `${left}${isMethod ? "" : ": "}${right}`;
 };

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -557,9 +557,9 @@ export const printType = withEnv((env: any, rawType: any): string => {
       return `${printType(type.type)} | void`;
     case ts.SyntaxKind.TupleType: {
       const lastElement = type.elementTypes[type.elementTypes.length - 1];
-      if (lastElement.kind === ts.SyntaxKind.RestType) type.elementTypes.pop();
+      if (lastElement && lastElement.kind === ts.SyntaxKind.RestType) type.elementTypes.pop();
       let tuple = `[${type.elementTypes.map(printType).join(", ")}]`;
-      if (lastElement.kind === ts.SyntaxKind.RestType) {
+      if (lastElement && lastElement.kind === ts.SyntaxKind.RestType) {
         tuple += ` & ${printType(lastElement.type)}`;
       }
       return tuple;

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -364,6 +364,22 @@ export const printType = (rawType: any): string => {
       return `/* ${line} */ any`;
     }
 
+    case ts.SyntaxKind.ComputedPropertyName: {
+      if (type.expression?.expression?.text === 'Symbol' && type.expression?.name?.text === 'iterator') {
+        return '@@iterator'
+      }
+      if (type.expression?.expression?.text === 'Symbol' && type.expression?.name?.text === 'asyncIterator') {
+        return '@@asyncIterator'
+      }
+      if (type.expression.kind === ts.SyntaxKind.StringLiteral) {
+        return printType(type.expression);
+      }
+      const line =
+        "Flow doesn't support computed property names";
+      logger.error(type.expression, line);
+      return `[typeof ${printType(type.expression)}]`;
+    }
+
     case ts.SyntaxKind.FunctionType:
       //case SyntaxKind.FunctionTypeAnnotation:
       return printers.functions.functionType(type);
@@ -592,8 +608,7 @@ export const printType = (rawType: any): string => {
 
       return (
         keywordPrefix +
-        printType(type.name) +
-        printers.functions.functionType(type, true)
+        printers.common.methodSignature(type)
       );
 
     case ts.SyntaxKind.ConstructorType:


### PR DESCRIPTION
- Add partial support for computed properties
  - Convert `[Symbol.iterator]` to `@@iterator`
  - Convert `[Symbol.asyncIterator]` to `@@asyncIterator`
  - Convert `[Foo]` to `[typeof Foo]` (this is indexer in Flow, so it would be invalid to have multiple indexers)
- Fix array binding parsing
   - `([]) => void` to `(x: any) => void`
- Add more JSDoc types
  - `@param {*}`
  - `@param {?}`
  - `@param {string=}`
  - `@param {?string}`
  - `@param {!string}`
  - `@param {...args}`
  - `@param {function(T)}`
- Fix class readonly and optional fields
- Add `--quiet` option
- Add better error messages
![image](https://user-images.githubusercontent.com/3275424/59557044-dfb6e200-8fe8-11e9-9fc8-063e8bb24075.png)
