### PR TITLE
Add newline after property declarations

### DIFF
--- a/src/__tests__/__snapshots__/string_literals.spec.js.snap
+++ b/src/__tests__/__snapshots__/string_literals.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should handle exported constant string literals 1`] = `
+"declare export var SET_NAME: any; // \\"my/lib/SET_NAME\\"
+declare export var SET_STAGE: any; // \\"my/lib/SET_STAGE\\"
+"
+`;
+
 exports[`should handle string literals in function argument "overloading" 1`] = `
 "declare interface MyObj {
   on(event: \\"error\\", cb: (err: Error) => void): this;

--- a/src/__tests__/string_literals.spec.js
+++ b/src/__tests__/string_literals.spec.js
@@ -19,3 +19,14 @@ it("should handle string literals in function argument \"overloading\"", () => {
 
   expect(beautify(result)).toMatchSnapshot();
 });
+
+it("should handle exported constant string literals", () => {
+  const ts = `
+  export declare const SET_NAME = "my/lib/SET_NAME";
+  export declare const SET_STAGE = "my/lib/SET_STAGE";
+  `;
+
+  const result = compiler.compileDefinitionString(ts, {quiet: true});
+
+  expect(beautify(result)).toMatchSnapshot();
+});

--- a/src/printers/declarations.js
+++ b/src/printers/declarations.js
@@ -53,7 +53,7 @@ export const propertyDeclaration = (
     return left + ": " + right;
   }
 
-  return left + `: any // ${printers.node.printType(node.initializer)}`;
+  return left + `: any // ${printers.node.printType(node.initializer)}\n`;
 };
 
 export const variableDeclaration = (node: RawNode): string => {


### PR DESCRIPTION
Since the type of the property initializer is added as a single line comment, we need to add a newline afterwards so that following type definitions don't get obscured by the same line comment.