### PR TITLE
Rename default output name to be compatible with Flow expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const readableDef = beautify(generatedFlowdef);
 
 ### CLI
 
-Standard usage (will produce `export.flow.js`):
+Standard usage (will produce `export.js.flow`):
 ```
 npm i -g flowgen
 flowgen lodash.d.ts
@@ -80,7 +80,7 @@ flowgen lodash.d.ts
 
 ### Options
 ```
--o / --output-file [outputFile]: Specifies the filename of the exported file, defaults to export.flow.js
+-o / --output-file [outputFile]: Specifies the filename of the exported file, defaults to export.js.flow
 ```
 
 ### Flags for specific cases

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,8 +9,8 @@ program
   .version(pkg.version)
   .option(
     "-o --output-file [outputFile]",
-    "name for output file, defaults to export.flow.js",
-    "export.flow.js",
+    "name for output file, defaults to export.js.flow",
+    "export.js.flow",
   )
   .option("--no-module-exports", "use only default exports")
   .option(


### PR DESCRIPTION
Hi there.

[Flow doc](https://flow.org/en/docs/libdefs/creation/#declaring-a-module-) mentions `.js.flow` as module declarations format. Why don't we change the default output value to correspond this point?