### PR TITLE
Add directory-flow-typed-format, inexact option, nested modules error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,16 @@ export type Options = {
 
 export type Compiler = {
   compileTest(path: string, target: string): void;
-  compileDefinitionString(string: string, options?: Options): string;
-  compileDefinitionFile(path: string, options?: Options): string;
+  compileDefinitionString(
+    string: string,
+    options?: Options,
+    mapSourceCode?: (source: string | void, fileName: string) => string | void,
+  ): string;
+  compileDefinitionFile(
+    path: string,
+    options?: Options,
+    mapSourceCode?: (source: string | void, fileName: string) => string | void,
+  ): string;
 
   // Low-level exports
   reset(options?: Options): void;

--- a/index.js.flow
+++ b/index.js.flow
@@ -8,8 +8,16 @@ export type Options = {|
 
 export type Compiler = {|
   compileTest(path: string, target: string): void,
-  compileDefinitionString(string: string, options?: Options): string,
-  compileDefinitionFile(path: string, options?: Options): string,
+  compileDefinitionString(
+    string: string,
+    options?: Options,
+    mapSourceCode?: (source: string | void, fileName: string) => string | void,
+  ): string,
+  compileDefinitionFile(
+    path: string,
+    options?: Options,
+    mapSourceCode?: (source: string | void, fileName: string) => string | void,
+  ): string,
 
   // Low-level exports
   reset(options?: Options): void,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "paralleljs": "^0.2.1",
     "prettier": "^1.16.4",
     "shelljs": "^0.8.3",
-    "typescript": "^3.3.3333",
+    "typescript": "^3.4",
     "typescript-compiler": "^1.4.1-2"
   },
   "devDependencies": {
@@ -52,6 +52,7 @@
     "eslint-plugin-jest": "^22.2.2",
     "flow-bin": "^0.102.0",
     "jest": "^24.5.0",
+    "next": "^9.0.3",
     "recast": "^0.18.1"
   },
   "files": [

--- a/src/__tests__/__snapshots__/basic.spec.js.snap
+++ b/src/__tests__/__snapshots__/basic.spec.js.snap
@@ -21,7 +21,8 @@ exports[`should handle basic keywords 1`] = `
   r: -1,
   s: -2,
   t: Symbol,
-  u: Symbol
+  u: Symbol,
+  ...
 };
 "
 `;

--- a/src/__tests__/__snapshots__/basic.spec.js.snap
+++ b/src/__tests__/__snapshots__/basic.spec.js.snap
@@ -22,6 +22,8 @@ exports[`should handle basic keywords 1`] = `
   s: -2,
   t: Symbol,
   u: Symbol,
+  v: [1, 2, 3],
+  w: $ReadOnlyArray<string>,
   ...
 };
 "

--- a/src/__tests__/__snapshots__/computed.spec.js.snap
+++ b/src/__tests__/__snapshots__/computed.spec.js.snap
@@ -9,7 +9,8 @@ exports[`should approximate unsupported keys 1`] = `
   [typeof Foo]: any | void,
   +[typeof Foo]: any | void,
   [typeof Foo]: any,
-  +[typeof Foo]: any
+  +[typeof Foo]: any,
+  ...
 };
 declare class B {
   [typeof Foo]: (() => any) | void;
@@ -51,7 +52,8 @@ exports[`should handle computed Symbol.iterator and Symbol.asyncIterator 1`] = `
   @@asyncIterator: any,
   @@iterator: any,
   +@@asyncIterator: any,
-  +@@iterator: any
+  +@@iterator: any,
+  ...
 };
 declare class B {
   @@asyncIterator: (() => any) | void;
@@ -101,7 +103,8 @@ exports[`should handle string literals 1`] = `
   foo: any | void,
   +foo: any | void,
   foo: any,
-  +foo: any
+  +foo: any,
+  ...
 };
 declare class B {
   foo: (() => any) | void;

--- a/src/__tests__/__snapshots__/import.spec.js.snap
+++ b/src/__tests__/__snapshots__/import.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle dynamic imports 1`] = `
+"declare type A = $Exports<\\"react\\">;
+declare type B = $PropertyType<$Exports<\\"react\\">, \\"ReactNode\\">;
+"
+`;

--- a/src/__tests__/__snapshots__/interfaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.js.snap
@@ -15,7 +15,8 @@ exports[`should handle interface inheritance 1`] = `
   firstName: string;
 }
 declare type SpecialUser = {
-  nice: number
+  nice: number,
+  ...
 } & User;
 "
 `;
@@ -86,7 +87,8 @@ exports[`should handle typed object binding pattern 1`] = `
   (x: any): void;
   (x: {
     a: string,
-    b: number
+    b: number,
+    ...
   }): void;
 }
 "
@@ -135,15 +137,15 @@ exports[`should support call signature 1`] = `
   <T: { [key: string]: any }>(
     fields?: ObjectSchemaDefinition<T>
   ): ObjectSchema<T>;
-  new(): ObjectSchema<{}>;
+  new(): ObjectSchema<{ ... }>;
 }
 "
 `;
 
 exports[`should support omitting generic defaults in types, classes, interfaces 1`] = `
 "declare interface Foo<T = Symbol, U = number> {}
-declare type FooBar = {} & Foo<>;
-declare type Bar<T = number, U = string> = {};
+declare type FooBar = { ... } & Foo<>;
+declare type Bar<T = number, U = string> = { ... };
 declare class Baz<T = string, U = number> {}
 declare var a: Foo<>;
 declare var b: Bar<>;

--- a/src/__tests__/__snapshots__/jsdoc.spec.js.snap
+++ b/src/__tests__/__snapshots__/jsdoc.spec.js.snap
@@ -28,7 +28,8 @@ declare type F = {
    * @param {number=} opt_idx - The index where the new entry should be inserted; if omitted or greater then the current size of the list, the entry is added at the end of the list;
    * a negative index is treated as being relative from the end of the list
    */
-  add(entry: any, opt_idx?: number): void
+  add(entry: any, opt_idx?: number): void,
+  ...
 };
 /**
  * Patches an Element with the the provided function. Exactly one top level
@@ -74,7 +75,8 @@ declare function init(
     devicePixelRatio?: number,
     renderer?: string,
     width?: number | string,
-    height?: number | string
+    height?: number | string,
+    ...
   }
 ): ECharts;
 

--- a/src/__tests__/__snapshots__/mapped-types.spec.js.snap
+++ b/src/__tests__/__snapshots__/mapped-types.spec.js.snap
@@ -2,12 +2,14 @@
 
 exports[`should handle mapped types 1`] = `
 "declare type Ref<T> = {
-  current: T | null
+  current: T | null,
+  ...
 };
 declare type SourceUnion = \\"a\\" | \\"b\\" | \\"c\\";
 declare type SourceObject = {
   a: number,
-  d: string
+  d: string,
+  ...
 };
 declare type MappedUnion = $ObjMapi<
   { [k: SourceUnion]: any },

--- a/src/__tests__/__snapshots__/module-identifiers.spec.js.snap
+++ b/src/__tests__/__snapshots__/module-identifiers.spec.js.snap
@@ -4,7 +4,8 @@ exports[`should handle global types jsx 1`] = `
 "import * as React from \\"react\\";
 declare function s(node: React$Node): void;
 declare type Props = {
-  children: React$Node
+  children: React$Node,
+  ...
 };
 declare class Component mixins React.Component<Props> {
   render(): React$Node;

--- a/src/__tests__/__snapshots__/modules.spec.js.snap
+++ b/src/__tests__/__snapshots__/modules.spec.js.snap
@@ -7,13 +7,16 @@ exports[`should handle module 1`] = `
   declare type Maybe<T> =
     | {
         type: \\"just\\",
-        value: T
+        value: T,
+        ...
       }
     | {
-        type: \\"nothing\\"
+        type: \\"nothing\\",
+        ...
       };
   declare export type Ref<T> = {
-    current: T
+    current: T,
+    ...
   };
   declare export var ok: number;
 }
@@ -47,11 +50,13 @@ exports[`should not merge distinct modules 1`] = `
     foo: string;
   }
 }
+
 declare module \\"B\\" {
   declare export interface A {
     baz: string;
   }
 }
+
 export interface A {
   bar: string;
 }

--- a/src/__tests__/__snapshots__/namespaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.js.snap
@@ -23,9 +23,9 @@ exports[`should handle merging with other types class 1`] = `
 }
 declare var Album: typeof npm$namespace$Album;
 
-declare var npm$namespace$Album: {
+declare var npm$namespace$Album: {|
   AlbumLabel: typeof Album$AlbumLabel
-};
+|};
 declare export class Album$AlbumLabel {}
 "
 `;
@@ -38,9 +38,9 @@ exports[`should handle merging with other types enum 1`] = `
 |};
 declare var Color: typeof npm$namespace$Color;
 
-declare var npm$namespace$Color: {
+declare var npm$namespace$Color: {|
   mixColor: typeof Color$mixColor
-};
+|};
 declare export function Color$mixColor(colorName: string): number;
 "
 `;
@@ -48,11 +48,11 @@ declare export function Color$mixColor(colorName: string): number;
 exports[`should handle merging with other types function const 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {
+declare var npm$namespace$test: {|
   (foo: number): string,
 
   ok: typeof test$ok
-};
+|};
 declare export var test$ok: number;
 "
 `;
@@ -60,9 +60,9 @@ declare export var test$ok: number;
 exports[`should handle merging with other types function interface 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {
+declare var npm$namespace$test: {|
   (foo: number): string
-};
+|};
 export interface test$Foo {
   bar: number;
 }
@@ -72,9 +72,9 @@ export interface test$Foo {
 exports[`should handle merging with other types function type 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {
+declare var npm$namespace$test: {|
   (foo: number): string
-};
+|};
 export type test$Foo = {
   bar: number,
   ...
@@ -85,9 +85,9 @@ export type test$Foo = {
 exports[`should handle namespace function merging 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {
+declare var npm$namespace$test: {|
   test: typeof test$test
-};
+|};
 declare function test$test(err: number): void;
 
 declare function test$test(response: string): string;
@@ -97,10 +97,10 @@ declare function test$test(response: string): string;
 exports[`should handle namespace merging 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {
+declare var npm$namespace$test: {|
   ok: typeof test$ok,
   error: typeof test$error
-};
+|};
 declare export var test$ok: number;
 
 declare export var test$error: string;
@@ -110,9 +110,9 @@ declare export var test$error: string;
 exports[`should handle namespaces 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {
+declare var npm$namespace$test: {|
   ok: typeof test$ok
-};
+|};
 declare export var test$ok: number;
 "
 `;
@@ -121,20 +121,20 @@ exports[`should handle nested namespaces 1`] = `
 "import * as external from \\"external\\";
 declare var E0: typeof npm$namespace$E0;
 
-declare var npm$namespace$E0: {
+declare var npm$namespace$E0: {|
   s1: typeof E0$s1,
 
   S1: typeof npm$namespace$E0$S1
-};
+|};
 declare type E0$A = external.type;
 
-declare var npm$namespace$E0$U1: {
+declare var npm$namespace$E0$U1: {|
   e2: typeof E0$U1$e2,
   E2: typeof E0$U1$E2,
 
   D1: typeof npm$namespace$E0$U1$D1,
   DD1: typeof npm$namespace$E0$U1$DD1
-};
+|};
 declare interface E0$U1$S3 {
   a: string;
   b: string;
@@ -146,15 +146,15 @@ declare var E0$U1$E2: {|
   +E: 1 // 1
 |};
 
-declare var npm$namespace$E0$U1$D1: {
+declare var npm$namespace$E0$U1$D1: {|
   S2: typeof npm$namespace$E0$U1$D1$S2
-};
+|};
 
-declare var npm$namespace$E0$U1$D1$S2: {
+declare var npm$namespace$E0$U1$D1$S2: {|
   n3: typeof E0$U1$D1$S2$n3,
 
   N3: typeof E0$U1$D1$S2$N3
-};
+|};
 declare interface E0$U1$D1$S2$S3 {
   b: string;
 }
@@ -167,9 +167,9 @@ declare interface E0$U1$DD1$S2$S3 {
   e: number;
 }
 
-declare var npm$namespace$E0$S1: {
+declare var npm$namespace$E0$S1: {|
   m3: typeof E0$S1$m3
-};
+|};
 declare var E0$S1$m3: string;
 
 declare var E0$s1: string;
@@ -179,14 +179,14 @@ declare var E0$s1: string;
 exports[`should handle qualified namespaces 1`] = `
 "declare var A: typeof npm$namespace$A;
 
-declare var npm$namespace$A: {
+declare var npm$namespace$A: {|
   B: typeof npm$namespace$A$B
-};
+|};
 
-declare var npm$namespace$A$B: {
+declare var npm$namespace$A$B: {|
   D: typeof A$B$D,
   C: typeof npm$namespace$A$B$C
-};
+|};
 declare interface A$B$S<A> {
   +d: A;
   b: number;
@@ -194,9 +194,9 @@ declare interface A$B$S<A> {
 
 declare class A$B$D<S> {}
 
-declare var npm$namespace$A$B$C: {
+declare var npm$namespace$A$B$C: {|
   N: typeof A$B$C$N
-};
+|};
 declare class A$B$C$N<A> mixins A$B$D<A>, A$B$S<A> {
   a: string;
 }

--- a/src/__tests__/__snapshots__/namespaces.spec.js.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.js.snap
@@ -76,7 +76,8 @@ declare var npm$namespace$test: {
   (foo: number): string
 };
 export type test$Foo = {
-  bar: number
+  bar: number,
+  ...
 };
 "
 `;

--- a/src/__tests__/__snapshots__/string-literals.spec.js.snap
+++ b/src/__tests__/__snapshots__/string-literals.spec.js.snap
@@ -15,7 +15,8 @@ exports[`should handle string literals in function argument "overloading" 1`] = 
     cb: (
       data: any,
       flags: {
-        binary: boolean
+        binary: boolean,
+        ...
       }
     ) => void
   ): this;
@@ -24,7 +25,8 @@ exports[`should handle string literals in function argument "overloading" 1`] = 
     cb: (
       data: any,
       flags: {
-        binary: boolean
+        binary: boolean,
+        ...
       }
     ) => void
   ): this;
@@ -33,7 +35,8 @@ exports[`should handle string literals in function argument "overloading" 1`] = 
     cb: (
       data: any,
       flags: {
-        binary: boolean
+        binary: boolean,
+        ...
       }
     ) => void
   ): this;

--- a/src/__tests__/__snapshots__/type-exports.spec.js.snap
+++ b/src/__tests__/__snapshots__/type-exports.spec.js.snap
@@ -5,10 +5,12 @@ exports[`should handle exported types 1`] = `
 export type Maybe<T> =
   | {
       type: \\"just\\",
-      value: T
+      value: T,
+      ...
     }
   | {
-      type: \\"nothing\\"
+      type: \\"nothing\\",
+      ...
     };
 "
 `;

--- a/src/__tests__/__snapshots__/utility-types.spec.js.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.js.snap
@@ -2,11 +2,13 @@
 
 exports[`should handle utility types 1`] = `
 "declare type A = $ReadOnly<{
-  a: number
+  a: number,
+  ...
 }>;
 declare type B = $Rest<
   {
-    a: number
+    a: number,
+    ...
   },
   {}
 >;

--- a/src/__tests__/__snapshots__/utility-types.spec.js.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.js.snap
@@ -10,12 +10,12 @@ declare type B = $Rest<
     a: number,
     ...
   },
-  {}
+  { ... }
 >;
 declare type C = $NonMaybeType<string | null>;
 declare type D = $ReadOnlyArray<string>;
 declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;
-declare type F = { [key: string]: number };
+declare type F = { [key: string]: number, ... };
 declare type G = $ReadOnlySet<number>;
 declare type H = $ReadOnlyMap<string, number>;
 declare type A1<Readonly> = Readonly;
@@ -25,10 +25,10 @@ declare type D1<ReadonlyArray> = ReadonlyArray;
 declare type E1<ReturnType> = ReturnType;
 declare type F1<Record> = Record;
 declare type A2<T> = $ReadOnly<T>;
-declare type B2<T> = $Rest<T, {}>;
+declare type B2<T> = $Rest<T, { ... }>;
 declare type C2<T> = $NonMaybeType<T>;
 declare type D2<T> = $ReadOnlyArray<T>;
 declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
-declare type F2<T, U> = { [key: T]: U };
+declare type F2<T, U> = { [key: T]: U, ... };
 "
 `;

--- a/src/__tests__/__snapshots__/value-exports.spec.js.snap
+++ b/src/__tests__/__snapshots__/value-exports.spec.js.snap
@@ -2,7 +2,8 @@
 
 exports[`should handle default exported es module values 1`] = `
 "declare var test: {
-  a: number
+  a: number,
+  ...
 };
 declare export default typeof test;
 "
@@ -10,7 +11,8 @@ declare export default typeof test;
 
 exports[`should handle exported es module values 1`] = `
 "declare var test: {
-  a: number
+  a: number,
+  ...
 };
 declare export { test };
 "

--- a/src/__tests__/__snapshots__/variables.spec.js.snap
+++ b/src/__tests__/__snapshots__/variables.spec.js.snap
@@ -2,7 +2,8 @@
 
 exports[`should handle declares 1`] = `
 "declare var test: {
-  a: number
+  a: number,
+  ...
 };
 declare var foo: string;
 declare var bar: number;

--- a/src/__tests__/basic.spec.js
+++ b/src/__tests__/basic.spec.js
@@ -24,6 +24,8 @@ it("should handle basic keywords", () => {
     s: -2,
     t: symbol,
     u: unique symbol,
+    v: readonly [1, 2, 3],
+    w: readonly string[],
   }`;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();

--- a/src/__tests__/import.spec.js
+++ b/src/__tests__/import.spec.js
@@ -1,0 +1,13 @@
+// @flow
+
+import { compiler, beautify } from "..";
+
+it("should handle dynamic imports", () => {
+  const ts = `
+type A = import('react');
+type B = import('react').ReactNode;
+`;
+  expect(
+    beautify(compiler.compileDefinitionString(ts, { quiet: true })),
+  ).toMatchSnapshot();
+});

--- a/src/cli/__tests__/__snapshots__/compiler.spec.js.snap
+++ b/src/cli/__tests__/__snapshots__/compiler.spec.js.snap
@@ -1,9 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle bounded polymorphism 1`] = `
-"declare function fooGood<T: {
-x: number,...
-}>(obj: T): T
+"declare function fooGood<
+  T: {
+    x: number,
+    ...
+  }
+>(
+  obj: T
+): T;
 "
 `;
 

--- a/src/cli/__tests__/__snapshots__/compiler.spec.js.snap
+++ b/src/cli/__tests__/__snapshots__/compiler.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should handle bounded polymorphism 1`] = `
 "declare function fooGood<T: {
-x: number
+x: number,...
 }>(obj: T): T
 "
 `;

--- a/src/cli/__tests__/__snapshots__/fixtures.spec.js.snap
+++ b/src/cli/__tests__/__snapshots__/fixtures.spec.js.snap
@@ -1,967 +1,942 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`handles the danger.d.ts correctly 1`] = `
-"import * as GitHub from '@octokit/rest';
-declare module 'danger' {
-        declare type MarkdownString = string;
-	
-/**
- * A platform agnostic reference to a Git commit
- */
-declare interface GitCommit {
+"import * as GitHub from \\"@octokit/rest\\";
 
-/**
- * The SHA for the commit
- */
-sha: string,
+declare module \\"danger\\" {
+  declare type MarkdownString = string;
 
-/**
- * Who wrote the commit
- */
-author: GitCommitAuthor,
+  /**
+   * A platform agnostic reference to a Git commit
+   */
+  declare interface GitCommit {
+    /**
+     * The SHA for the commit
+     */
+    sha: string;
 
-/**
- * Who deployed the commit
- */
-committer: GitCommitAuthor,
+    /**
+     * Who wrote the commit
+     */
+    author: GitCommitAuthor;
 
-/**
- * The commit message
- */
-message: string,
+    /**
+     * Who deployed the commit
+     */
+    committer: GitCommitAuthor;
 
-/**
- * Potential parent commits, and other assorted metadata
- */
-tree: any,
+    /**
+     * The commit message
+     */
+    message: string;
 
-/**
- * SHAs for the commit's parents
- */
-parents?: string[],
+    /**
+     * Potential parent commits, and other assorted metadata
+     */
+    tree: any;
 
-/**
- * Link to the commit
- */
-url: string
-} 
-	
-/**
- * An author of a commit
- */
-declare interface GitCommitAuthor {
+    /**
+     * SHAs for the commit's parents
+     */
+    parents?: string[];
 
-/**
- * The display name for the author
- */
-name: string,
+    /**
+     * Link to the commit
+     */
+    url: string;
+  }
 
-/**
- * The authors email
- */
-email: string,
+  /**
+   * An author of a commit
+   */
+  declare interface GitCommitAuthor {
+    /**
+     * The display name for the author
+     */
+    name: string;
 
-/**
- * ISO6801 date string
- */
-date: string
-} 
-	
-/**
- * The shape of the JSON passed between Danger and a subprocess. It's built
- * to be expanded in the future.
- */
-declare interface DangerJSON {
-danger: DangerDSLJSONType
-} 
-	
-/**
- * The available Peril interface, it is possible that this is not
- * always up to date with true DSL in Peril, but I'll be giving it
- * a good shot.
- */
-declare interface PerilDSL {
+    /**
+     * The authors email
+     */
+    email: string;
 
-/**
- * A set of key:value string based on ENV vars that have
- * been set to be exposed to your Peril config
- */
-env: any,
+    /**
+     * ISO6801 date string
+     */
+    date: string;
+  }
 
-/**
- * Allows you to schedule a task declared in your Peril config to run in a certain timeframe,
- * e.g \`runTask(\\"reminder_pr_merge\\", \\"in 2 days\\", { number: 2 })\`. For more details on how this
- * works, see the Peril documentation.
- * @param taskName the name found in your Peril config
- * @param time the time interval (uses human-internal module)
- * @param data data which will be passed through to the script
- */
-runTask: (taskName: string, time: string, data: any) => void,
+  /**
+   * The shape of the JSON passed between Danger and a subprocess. It's built
+   * to be expanded in the future.
+   */
+  declare interface DangerJSON {
+    danger: DangerDSLJSONType;
+  }
 
-/**
- * When running a task, the data passed in when the task
- * was originally scheduled.
- */
-data?: any
-} 
-	
-/**
- * The root of the Danger JSON DSL.
- */
-declare interface DangerDSLJSONType {
+  /**
+   * The available Peril interface, it is possible that this is not
+   * always up to date with true DSL in Peril, but I'll be giving it
+   * a good shot.
+   */
+  declare interface PerilDSL {
+    /**
+     * A set of key:value string based on ENV vars that have
+     * been set to be exposed to your Peril config
+     */
+    env: any;
 
-/**
- * The data only version of Git DSL
- */
-git: GitJSONDSL,
+    /**
+     * Allows you to schedule a task declared in your Peril config to run in a certain timeframe,
+     * e.g \`runTask(\\"reminder_pr_merge\\", \\"in 2 days\\", { number: 2 })\`. For more details on how this
+     * works, see the Peril documentation.
+     * @param taskName the name found in your Peril config
+     * @param time the time interval (uses human-internal module)
+     * @param data data which will be passed through to the script
+     */
+    runTask: (taskName: string, time: string, data: any) => void;
 
-/**
- * The data only version of GitHub DSL
- */
-github: GitHubDSL,
+    /**
+     * When running a task, the data passed in when the task
+     * was originally scheduled.
+     */
+    data?: any;
+  }
 
-/**
- * Used in the Danger JSON DSL to pass metadata between
- * processes. It will be undefined when used inside the Danger DSL
- */
-settings: {
+  /**
+   * The root of the Danger JSON DSL.
+   */
+  declare interface DangerDSLJSONType {
+    /**
+     * The data only version of Git DSL
+     */
+    git: GitJSONDSL;
 
-/**
- * Saves each client re-implmenting logic to grab these vars
- * for their API clients
- */
-github: {
+    /**
+     * The data only version of GitHub DSL
+     */
+    github: GitHubDSL;
 
-/**
- * API token for the GitHub client to use
- */
-accessToken: string,
+    /**
+     * Used in the Danger JSON DSL to pass metadata between
+     * processes. It will be undefined when used inside the Danger DSL
+     */
+    settings: {
+      /**
+       * Saves each client re-implmenting logic to grab these vars
+       * for their API clients
+       */
+      github: {
+        /**
+         * API token for the GitHub client to use
+         */
+        accessToken: string,
 
-/**
- * Optional URL for enterprise GitHub
- */
-baseURL: string | void,
+        /**
+         * Optional URL for enterprise GitHub
+         */
+        baseURL: string | void,
 
-/**
- * Optional headers to add to a request
- */
-additionalHeaders: any
-},
+        /**
+         * Optional headers to add to a request
+         */
+        additionalHeaders: any,
+        ...
+      },
 
-/**
- * This is still a bit of a WIP, but this should
- * pass args/opts from the original CLI call through
- * to the process.
- */
-cliArgs: CliArgs
+      /**
+       * This is still a bit of a WIP, but this should
+       * pass args/opts from the original CLI call through
+       * to the process.
+       */
+      cliArgs: CliArgs,
+      ...
+    };
+  }
+
+  /**
+   * The Danger DSL provides the metadata for introspection
+   * in order to create your own rules.
+   */
+  declare interface DangerDSLType {
+    /**
+     * Details specific to the git changes within the code changes.
+     * Currently, this is just the raw file paths that have been
+     * added, removed or modified.
+     */
+    +git: GitDSL;
+
+    /**
+     * The GitHub metadata. This covers things like PR info,
+     * comments and reviews on the PR, label metadata, commits with
+     * GitHub user identities and some useful utility functions
+     * for displaying links to files.
+     *
+     * Provides an authenticated API so you can work directly
+     * with the GitHub API. This is an instance of the \\"@ocktokit/rest\\" npm
+     * module.
+     *
+     * Finally, if running through Peril on an event other than a PR
+     * this is the full JSON from the webhook. You can find the full
+     * typings for those webhooks [at github-webhook-event-types](https://github.com/orta/github-webhook-event-types).
+     */
+    +github: GitHubDSL;
+
+    /**
+     * Functions which are globally useful in most Dangerfiles. Right
+     * now, these functions are around making sentences of arrays, or
+     * for making hrefs easily.
+     */
+    +utils: DangerUtilsDSL;
+  }
+
+  /**
+   * The representation of what running a Dangerfile generates.
+   *
+   * In the future I'd like this to be cross process, so please
+   * do not add functions, only data to this interface.
+   */
+  declare interface DangerResults {
+    /**
+     * Failed messages
+     */
+    fails: Violation[];
+
+    /**
+     * Messages for info
+     */
+    warnings: Violation[];
+
+    /**
+     * A set of messages to show inline
+     */
+    messages: Violation[];
+
+    /**
+     * Markdown messages to attach at the bottom of the comment
+     */
+    markdowns: MarkdownString[];
+  }
+  declare type DangerRuntimeContainer = {
+    /**
+     * Asynchronous functions to be run after parsing
+     */
+    scheduled?: any[],
+    ...
+  } & DangerResults;
+
+  /**
+   * The Danger Utils DSL contains utility functions
+   * that are specific to universal Danger use-cases.
+   */
+  declare interface DangerUtilsDSL {
+    /**
+     * Creates a link using HTML.
+     *
+     * If \`href\` and \`text\` are falsy, null is returned.
+     * If \`href\` is falsy and \`text\` is truthy, \`text\` is returned.
+     * If \`href\` is truthy and \`text\` is falsy, an <a> tag is returned with \`href\` as its href and text value.
+     * Otherwise, if \`href\` and \`text\` are truthy, an <a> tag is returned with the \`href\` and \`text\` inserted as expected.
+     * @param {string} href The HTML link's destination.
+     * @param {string} text The HTML link's text.
+     * @returns {string | null} The HTML <a> tag.
+     */
+    href(href: string, text: string): string | null;
+
+    /**
+     * Converts an array of strings into a sentence.
+     * @param {string[]} array The array of strings.
+     * @returns {string} The sentence.
+     */
+    sentence(array: string[]): string;
+  }
+
+  /**
+   * All Text diff values will be this shape
+   */
+  declare interface TextDiff {
+    /**
+     * The value before the PR's applied changes
+     */
+    before: string;
+
+    /**
+     * The value after the PR's applied changes
+     */
+    after: string;
+
+    /**
+     * A string containing the full set of changes
+     */
+    diff: string;
+
+    /**
+     * A string containing just the added lines
+     */
+    added: string;
+
+    /**
+     * A string containing just the removed lines
+     */
+    removed: string;
+  }
+
+  /**
+   * The results of running a JSON patch
+   */
+  declare interface JSONPatch {
+    /**
+     * The JSON in a file at the PR merge base
+     */
+    before: any;
+
+    /**
+     * The JSON in a file from the PR submitter
+     */
+    after: any;
+
+    /**
+     * The set of operations to go from one JSON to another JSON
+     */
+    diff: JSONPatchOperation[];
+  }
+
+  /**
+   * An individual operation inside an rfc6902 JSON Patch
+   */
+  declare interface JSONPatchOperation {
+    /**
+     * An operation type
+     */
+    op: string;
+
+    /**
+     * The JSON keypath which the operation applies on
+     */
+    path: string;
+
+    /**
+     * The changes for applied
+     */
+    value: string;
+  }
+
+  /**
+   * All JSON diff values will be this shape
+   */
+  declare interface JSONDiffValue {
+    /**
+     * The value before the PR's applied changes
+     */
+    before: any;
+
+    /**
+     * The value after the PR's applied changes
+     */
+    after: any;
+
+    /**
+     * If both before & after are arrays, then you optionally get what is added. Empty if no additional objects.
+     */
+    added?: any[];
+
+    /**
+     * If both before & after are arrays, then you optionally get what is removed. Empty if no removed objects.
+     */
+    removed?: any[];
+  }
+
+  /**
+   * A map of string keys to JSONDiffValue
+   */
+  declare interface JSONDiff {
+    [name: string]: JSONDiffValue;
+  }
+
+  /**
+   * The Git Related Metadata which is available inside the Danger DSL JSON
+   * @namespace JSONDSL
+   */
+  declare interface GitJSONDSL {
+    /**
+     * Filepaths with changes relative to the git root
+     */
+    +modified_files: string[];
+
+    /**
+     * Newly created filepaths relative to the git root
+     */
+    +created_files: string[];
+
+    /**
+     * Removed filepaths relative to the git root
+     */
+    +deleted_files: string[];
+
+    /**
+     * The Git commit metadata
+     */
+    +commits: GitCommit[];
+  }
+
+  /**
+   * The git specific metadata for a PR
+   */
+  declare type GitDSL = {
+    /**
+     * Offers the diff for a specific file
+     * @param {string} filename the path to the json file
+     */
+    diffForFile(filename: string): Promise<TextDiff | null>,
+
+    /**
+     * Provides a JSON patch (rfc6902) between the two versions of a JSON file,
+     * returns null if you don't have any changes for the file in the diff.
+     *
+     * Note that if you are looking to just see changes like: before, after, added or removed - you
+     * should use \`JSONDiffForFile\` instead, as this can be a bit unweildy for a Dangerfile.
+     * @param {string} filename the path to the json file
+     */
+    JSONPatchForFile(filename: string): Promise<JSONPatch | null>,
+
+    /**
+     * Provides a simplified JSON diff between the two versions of a JSON file. This will always
+     * be an object whose keys represent what has changed inside a JSON file.
+     *
+     * Any changed values will be represented with the same path, but with a different object instead.
+     * This object will always show a \`before\` and \`after\` for the changes. If both values are arrays or
+     * objects the \`before\` and \`after\`, then there will also be \`added\` and \`removed\` inside the object.
+     *
+     * In the case of two objects, the \`added\` and \`removed\` will be an array of keys rather than the values.
+     *
+     * This object is represented as \`JSONDiffValue\` but I don't know how to make TypeScript force
+     * declare that kind of type structure.
+     *
+     * This should make it really easy to do work when specific keypaths have changed inside a JSON file.
+     * @param {string} filename the path to the json file
+     */
+    JSONDiffForFile(filename: string): Promise<JSONDiff>,
+    ...
+  } & GitJSONDSL;
+
+  declare interface GitHubJSONDSL {
+    /**
+     * The issue metadata for a code review session
+     */
+    issue: GitHubIssue;
+
+    /**
+     * The PR metadata for a code review session
+     */
+    pr: GitHubPRDSL;
+
+    /**
+     * The PR metadata specifically formatted for using with the GitHub API client
+     */
+    thisPR: GitHubAPIPR;
+
+    /**
+     * The github commit metadata for a code review session
+     */
+    commits: GitHubCommit[];
+
+    /**
+     * The reviews left on this pull request
+     */
+    reviews: GitHubReview[];
+
+    /**
+     * The people requested to review this PR
+     */
+    requested_reviewers: GitHubUser[];
+  }
+
+  /**
+   * The GitHub metadata for your PR
+   */
+  declare type GitHubDSL = {
+    /**
+     * An authenticated API so you can extend danger's behavior by using the [GitHub v3 API](https://developer.github.com/v3/).
+     *
+     * A set up instance of the \\"github\\" npm module. You can get the full [API here](https://octokit.github.io/node-github/).
+     */
+    api: GitHub,
+
+    /**
+     * A scope for useful functions related to GitHub
+     */
+    utils: GitHubUtilsDSL,
+    ...
+  } & GitHubJSONDSL;
+
+  /**
+   * Useful functions for GitHub related work
+   */
+  declare interface GitHubUtilsDSL {
+    /**
+     * Creates HTML for a sentence of clickable links for an array of paths.
+     * This uses the source of the PR as the target, not the destination repo.
+     * You can manually set the target repo and branch however, to make it work how you want.
+     * @param {string} paths A list of strings representing file paths
+     * @param {string} useBasename Show either the file name, or the full path - defaults to just file name e.g. true.
+     * @param {string} repoSlug An optional override for the repo slug, ex: \\"orta/ORStackView\\"
+     * @param {string} branch An optional override for the branch, ex: \\"v3\\"
+     * @returns {string} A HTML string of <a>'s built as a sentence.
+     */
+    fileLinks(
+      paths: string[],
+      useBasename?: boolean,
+      repoSlug?: string,
+      branch?: string
+    ): string;
+
+    /**
+     * Downloads a file's contents via the GitHub API. You'll want to use
+     * this instead of \`fs.readFile\` when aiming to support working with Peril.
+     * @param {string} path The path fo the file that exists
+     * @param {string} repoSlug An optional reference to the repo's slug: e.g. danger/danger-js
+     * @param {string} ref An optional reference to a branch/sha
+     */
+    fileContents(
+      path: string,
+      repoSlug?: string,
+      ref?: string
+    ): Promise<string>;
+  }
+
+  /**
+   * This is \`danger.github.issue\` It refers to the issue that makes up the Pull Request.
+   * GitHub treats all pull requests as a special type of issue. This DSL contains only parts of the issue that are
+   * not found in the PR DSL, however it does contain the full JSON structure.
+   *
+   * A GitHub Issue
+   */
+  declare interface GitHubIssue {
+    /**
+     * The labels associated with this issue
+     */
+    labels: GitHubIssueLabel[];
+  }
+  declare interface GitHubIssueLabel {
+    /**
+     * The identifying number of this label
+     */
+    id: number;
+
+    /**
+     * The URL that links to this label
+     */
+    url: string;
+
+    /**
+     * The name of the label
+     */
+    name: string;
+
+    /**
+     * The color associated with this label
+     */
+    color: string;
+  }
+
+  /**
+   * An exact copy of the PR's reference JSON. This interface has type'd the majority
+   * of it for tooling's sake, but any extra metadata which GitHub send will still be
+   * inside the JS object.
+   */
+  declare interface GitHubPRDSL {
+    /**
+     * The UUID for the PR
+     */
+    number: number;
+
+    /**
+     * The state for the PR
+     */
+    state: \\"closed\\" | \\"open\\" | \\"locked\\" | \\"merged\\";
+
+    /**
+     * Has the PR been locked to contributors only?
+     */
+    locked: boolean;
+
+    /**
+     * The title of the PR
+     */
+    title: string;
+
+    /**
+     * The markdown body message of the PR
+     */
+    body: string;
+
+    /**
+     * ISO6801 Date string for when PR was created
+     */
+    created_at: string;
+
+    /**
+     * ISO6801 Date string for when PR was updated
+     */
+    updated_at: string;
+
+    /**
+     * optional ISO6801 Date string for when PR was closed
+     */
+    closed_at: string | null;
+
+    /**
+     * Optional ISO6801 Date string for when PR was merged.
+     * Danger probably shouldn't be running in this state.
+     */
+    merged_at: string | null;
+
+    /**
+     * Merge reference for the _other_ repo.
+     */
+    head: GitHubMergeRef;
+
+    /**
+     * Merge reference for _this_ repo.
+     */
+    base: GitHubMergeRef;
+
+    /**
+     * The User who submitted the PR
+     */
+    user: GitHubUser;
+
+    /**
+     * The User who is assigned the PR
+     */
+    assignee: GitHubUser;
+
+    /**
+     * The Users who are assigned to the PR
+     */
+    assignees: GitHubUser[];
+
+    /**
+     * Has the PR been merged yet?
+     */
+    merged: boolean;
+
+    /**
+     * The number of comments on the PR
+     */
+    comments: number;
+
+    /**
+     * The number of review-specific comments on the PR
+     */
+    review_comments: number;
+
+    /**
+     * The number of commits in the PR
+     */
+    commits: number;
+
+    /**
+     * The number of additional lines in the PR
+     */
+    additions: number;
+
+    /**
+     * The number of deleted lines in the PR
+     */
+    deletions: number;
+
+    /**
+     * The number of changed files in the PR
+     */
+    changed_files: number;
+  }
+
+  /**
+   * A GitHub specific implmentation of a git commit, it has GitHub user names instead of an email.
+   */
+  declare interface GitHubCommit {
+    /**
+     * The raw commit metadata
+     */
+    commit: GitCommit;
+
+    /**
+     * The SHA for the commit
+     */
+    sha: string;
+
+    /**
+     * the url for the commit on GitHub
+     */
+    url: string;
+
+    /**
+     * The GitHub user who wrote the code
+     */
+    author: GitHubUser;
+
+    /**
+     * The GitHub user who shipped the code
+     */
+    committer: GitHubUser;
+
+    /**
+     * An array of parent commit shas
+     */
+    parents: any[];
+  }
+
+  /**
+   * A GitHub user account.
+   */
+  declare interface GitHubUser {
+    /**
+     * Generic UUID
+     */
+    id: number;
+
+    /**
+     * The handle for the user/org
+     */
+    login: string;
+
+    /**
+     * Whether the user is an org, or a user
+     */
+    type: \\"User\\" | \\"Organization\\";
+
+    /**
+     * The url for a users's image
+     */
+    avatar_url: string;
+  }
+
+  /**
+   * A GitHub Repo
+   */
+  declare interface GitHubRepo {
+    /**
+     * Generic UUID
+     */
+    id: number;
+
+    /**
+     * The name of the repo, e.g. \\"Danger-JS\\"
+     */
+    name: string;
+
+    /**
+     * The full name of the owner + repo, e.g. \\"Danger/Danger-JS\\"
+     */
+    full_name: string;
+
+    /**
+     * The owner of the repo
+     */
+    owner: GitHubUser;
+
+    /**
+     * Is the repo publicly accessible?
+     */
+    private: boolean;
+
+    /**
+     * The textual description of the repo
+     */
+    description: string;
+
+    /**
+     * Is the repo a fork?
+     */
+    fork: boolean;
+
+    /**
+     * Is someone assigned to this PR?
+     */
+    assignee: GitHubUser;
+
+    /**
+     * Are there people assigned to this PR?
+     */
+    assignees: GitHubUser[];
+
+    /**
+     * The root web URL for the repo, e.g. https://github.com/artsy/emission
+     */
+    html_url: string;
+  }
+  declare interface GitHubMergeRef {
+    /**
+     * The human display name for the merge reference, e.g. \\"artsy:master\\"
+     */
+    label: string;
+
+    /**
+     * The reference point for the merge, e.g. \\"master\\"
+     */
+    ref: string;
+
+    /**
+     * The reference point for the merge, e.g. \\"704dc55988c6996f69b6873c2424be7d1de67bbe\\"
+     */
+    sha: string;
+
+    /**
+     * The user that owns the merge reference e.g. \\"artsy\\"
+     */
+    user: GitHubUser;
+
+    /**
+     * The repo from whch the reference comes from
+     */
+    repo: GitHubRepo;
+  }
+
+  /**
+   * GitHubReview
+   * While a review is pending, it will only have a user.  Once a review is complete, the rest of
+   * the review attributes will be present
+   * @export
+   * @interface GitHubReview
+   */
+  declare interface GitHubReview {
+    /**
+     * The user requested to review, or the user who has completed the review
+     */
+    user: GitHubUser;
+
+    /**
+     * If there is a review, this provides the ID for it
+     */
+    id?: number;
+
+    /**
+     * If there is a review, the body of the review
+     */
+    body?: string;
+
+    /**
+     * If there is a review, the commit ID this review was made on
+     */
+    commit_id?: string;
+
+    /**
+     * The state of the review
+     * APPROVED, REQUEST_CHANGES, COMMENT or PENDING
+     */
+    state?: \\"APPROVED\\" | \\"REQUEST_CHANGES\\" | \\"COMMENT\\" | \\"PENDING\\";
+  }
+
+  /**
+   * Provides the current PR in an easily used way for params in \`github.api\` calls
+   */
+  declare interface GitHubAPIPR {
+    /**
+     * The repo owner
+     */
+    owner: string;
+
+    /**
+     * The repo name
+     */
+    repo: string;
+
+    /**
+     * The PR number
+     */
+    number: number;
+  }
+
+  /**
+   * The result of user doing warn, message or fail, built this way for
+   * expansion later.
+   */
+  declare interface Violation {
+    /**
+     * The string representation
+     */
+    message: string;
+  }
+
+  /**
+   * Describes the possible arguments that
+   * could be used when calling the CLI
+   */
+  declare interface CliArgs {
+    base: string;
+    verbose: string;
+    externalCiProvider: string;
+    textOnly: string;
+    dangerfile: string;
+    id: string;
+  }
+
+  /**
+   * A function with a callback function, which Danger wraps in a Promise
+   */
+  declare type CallbackableFn = (callback: (done: any) => void) => void;
+
+  /**
+   * Types of things which Danger will schedule for you, it's recommended that you
+   * just throw in an \`async () => { [...] }\` function. Can also handle a function
+   * that has a single 'done' arg.
+   */
+  declare type Scheduleable = Promise<any> | Promise<void> | CallbackableFn;
+
+  /**
+   * A Dangerfile, in Peril, is evaluated as a script, and so async code does not work
+   * out of the box. By using the \`schedule\` function you can now register a
+   * section of code to evaluate across multiple tick cycles.
+   *
+   * \`schedule\` currently handles two types of arguments, either a promise or a function with a resolve arg.
+   * @param {Function} asyncFunction the function to run asynchronously
+   */
+  declare function schedule(asyncFunction: Scheduleable): void;
+
+  /**
+   * Fails a build, outputting a specific reason for failing into a HTML table.
+   * @param {MarkdownString} message the String to output
+   */
+  declare function fail(message: MarkdownString): void;
+
+  /**
+   * Highlights low-priority issues, but does not fail the build. Message
+   * is shown inside a HTML table.
+   * @param {MarkdownString} message the String to output
+   */
+  declare function warn(message: MarkdownString): void;
+
+  /**
+   * Adds a message to the Danger table, the only difference between this
+   * and warn is the emoji which shows in the table.
+   * @param {MarkdownString} message the String to output
+   */
+  declare function message(message: MarkdownString): void;
+
+  /**
+   * Adds raw markdown into the Danger comment, under the table
+   * @param {MarkdownString} message the String to output
+   */
+  declare function markdown(message: MarkdownString): void;
+
+  /**
+   * The root Danger object. This contains all of the metadata you
+   * will be looking for in order to generate useful rules.
+   */
+  declare var danger: DangerDSLType;
+
+  /**
+   * When Peril is running your Dangerfile, the Danger DSL is
+   * extended with additional options.
+   */
+  declare var peril: PerilDSL;
+
+  /**
+   * The current results of a Danger run, this can be useful if you
+   * are wanting to introspect on whether a build has already failed.
+   */
+  declare var results: DangerRuntimeContainer;
 }
-} 
-	
-/**
- * The Danger DSL provides the metadata for introspection
- * in order to create your own rules.
- */
-declare interface DangerDSLType {
-
-/**
- * Details specific to the git changes within the code changes.
- * Currently, this is just the raw file paths that have been
- * added, removed or modified.
- */
-+git: GitDSL,
-
-/**
- * The GitHub metadata. This covers things like PR info,
- * comments and reviews on the PR, label metadata, commits with
- * GitHub user identities and some useful utility functions
- * for displaying links to files.
- * 
- * Provides an authenticated API so you can work directly
- * with the GitHub API. This is an instance of the \\"@ocktokit/rest\\" npm
- * module.
- * 
- * Finally, if running through Peril on an event other than a PR
- * this is the full JSON from the webhook. You can find the full
- * typings for those webhooks [at github-webhook-event-types](https://github.com/orta/github-webhook-event-types).
- */
-+github: GitHubDSL,
-
-/**
- * Functions which are globally useful in most Dangerfiles. Right
- * now, these functions are around making sentences of arrays, or
- * for making hrefs easily.
- */
-+utils: DangerUtilsDSL
-} 
-	
-/**
- * The representation of what running a Dangerfile generates.
- * 
- * In the future I'd like this to be cross process, so please
- * do not add functions, only data to this interface.
- */
-declare interface DangerResults {
-
-/**
- * Failed messages
- */
-fails: Violation[],
-
-/**
- * Messages for info
- */
-warnings: Violation[],
-
-/**
- * A set of messages to show inline
- */
-messages: Violation[],
-
-/**
- * Markdown messages to attach at the bottom of the comment
- */
-markdowns: MarkdownString[]
-} 
-	declare type DangerRuntimeContainer = {
-
-/**
- * Asynchronous functions to be run after parsing
- */
-scheduled?: any[]
-} & DangerResults
-
-	
-/**
- * The Danger Utils DSL contains utility functions
- * that are specific to universal Danger use-cases.
- */
-declare interface DangerUtilsDSL {
-
-/**
- * Creates a link using HTML.
- * 
- * If \`href\` and \`text\` are falsy, null is returned.
- * If \`href\` is falsy and \`text\` is truthy, \`text\` is returned.
- * If \`href\` is truthy and \`text\` is falsy, an <a> tag is returned with \`href\` as its href and text value.
- * Otherwise, if \`href\` and \`text\` are truthy, an <a> tag is returned with the \`href\` and \`text\` inserted as expected.
- * @param {string} href The HTML link's destination.
- * @param {string} text The HTML link's text.
- * @returns {string | null} The HTML <a> tag.
- */
-href(href: string, text: string): string | null,
-
-/**
- * Converts an array of strings into a sentence.
- * @param {string[]} array The array of strings.
- * @returns {string} The sentence.
- */
-sentence(array: string[]): string
-} 
-	
-/**
- * All Text diff values will be this shape
- */
-declare interface TextDiff {
-
-/**
- * The value before the PR's applied changes
- */
-before: string,
-
-/**
- * The value after the PR's applied changes
- */
-after: string,
-
-/**
- * A string containing the full set of changes
- */
-diff: string,
-
-/**
- * A string containing just the added lines
- */
-added: string,
-
-/**
- * A string containing just the removed lines
- */
-removed: string
-} 
-	
-/**
- * The results of running a JSON patch
- */
-declare interface JSONPatch {
-
-/**
- * The JSON in a file at the PR merge base
- */
-before: any,
-
-/**
- * The JSON in a file from the PR submitter
- */
-after: any,
-
-/**
- * The set of operations to go from one JSON to another JSON
- */
-diff: JSONPatchOperation[]
-} 
-	
-/**
- * An individual operation inside an rfc6902 JSON Patch
- */
-declare interface JSONPatchOperation {
-
-/**
- * An operation type
- */
-op: string,
-
-/**
- * The JSON keypath which the operation applies on
- */
-path: string,
-
-/**
- * The changes for applied
- */
-value: string
-} 
-	
-/**
- * All JSON diff values will be this shape
- */
-declare interface JSONDiffValue {
-
-/**
- * The value before the PR's applied changes
- */
-before: any,
-
-/**
- * The value after the PR's applied changes
- */
-after: any,
-
-/**
- * If both before & after are arrays, then you optionally get what is added. Empty if no additional objects.
- */
-added?: any[],
-
-/**
- * If both before & after are arrays, then you optionally get what is removed. Empty if no removed objects.
- */
-removed?: any[]
-} 
-	
-/**
- * A map of string keys to JSONDiffValue
- */
-declare interface JSONDiff {
-[name: string]: JSONDiffValue
-} 
-	
-/**
- * The Git Related Metadata which is available inside the Danger DSL JSON
- * @namespace JSONDSL
- */
-declare interface GitJSONDSL {
-
-/**
- * Filepaths with changes relative to the git root
- */
-+modified_files: string[],
-
-/**
- * Newly created filepaths relative to the git root
- */
-+created_files: string[],
-
-/**
- * Removed filepaths relative to the git root
- */
-+deleted_files: string[],
-
-/**
- * The Git commit metadata
- */
-+commits: GitCommit[]
-} 
-	
-/**
- * The git specific metadata for a PR
- */
-declare type GitDSL = {
-
-/**
- * Offers the diff for a specific file
- * @param {string} filename the path to the json file
- */
-diffForFile(filename: string): Promise<TextDiff | null>,
-
-/**
- * Provides a JSON patch (rfc6902) between the two versions of a JSON file,
- * returns null if you don't have any changes for the file in the diff.
- * 
- * Note that if you are looking to just see changes like: before, after, added or removed - you
- * should use \`JSONDiffForFile\` instead, as this can be a bit unweildy for a Dangerfile.
- * @param {string} filename the path to the json file
- */
-JSONPatchForFile(filename: string): Promise<JSONPatch | null>,
-
-/**
- * Provides a simplified JSON diff between the two versions of a JSON file. This will always
- * be an object whose keys represent what has changed inside a JSON file.
- * 
- * Any changed values will be represented with the same path, but with a different object instead.
- * This object will always show a \`before\` and \`after\` for the changes. If both values are arrays or
- * objects the \`before\` and \`after\`, then there will also be \`added\` and \`removed\` inside the object.
- * 
- * In the case of two objects, the \`added\` and \`removed\` will be an array of keys rather than the values.
- * 
- * This object is represented as \`JSONDiffValue\` but I don't know how to make TypeScript force
- * declare that kind of type structure.
- * 
- * This should make it really easy to do work when specific keypaths have changed inside a JSON file.
- * @param {string} filename the path to the json file
- */
-JSONDiffForFile(filename: string): Promise<JSONDiff>
-} & GitJSONDSL
-
-	declare interface GitHubJSONDSL {
-
-/**
- * The issue metadata for a code review session
- */
-issue: GitHubIssue,
-
-/**
- * The PR metadata for a code review session
- */
-pr: GitHubPRDSL,
-
-/**
- * The PR metadata specifically formatted for using with the GitHub API client
- */
-thisPR: GitHubAPIPR,
-
-/**
- * The github commit metadata for a code review session
- */
-commits: GitHubCommit[],
-
-/**
- * The reviews left on this pull request
- */
-reviews: GitHubReview[],
-
-/**
- * The people requested to review this PR
- */
-requested_reviewers: GitHubUser[]
-} 
-	
-/**
- * The GitHub metadata for your PR
- */
-declare type GitHubDSL = {
-
-/**
- * An authenticated API so you can extend danger's behavior by using the [GitHub v3 API](https://developer.github.com/v3/).
- * 
- * A set up instance of the \\"github\\" npm module. You can get the full [API here](https://octokit.github.io/node-github/).
- */
-api: GitHub,
-
-/**
- * A scope for useful functions related to GitHub
- */
-utils: GitHubUtilsDSL
-} & GitHubJSONDSL
-
-	
-/**
- * Useful functions for GitHub related work
- */
-declare interface GitHubUtilsDSL {
-
-/**
- * Creates HTML for a sentence of clickable links for an array of paths.
- * This uses the source of the PR as the target, not the destination repo.
- * You can manually set the target repo and branch however, to make it work how you want.
- * @param {string} paths A list of strings representing file paths
- * @param {string} useBasename Show either the file name, or the full path - defaults to just file name e.g. true.
- * @param {string} repoSlug An optional override for the repo slug, ex: \\"orta/ORStackView\\"
- * @param {string} branch An optional override for the branch, ex: \\"v3\\"
- * @returns {string} A HTML string of <a>'s built as a sentence.
- */
-fileLinks(
-paths: string[],
-useBasename?: boolean,
-repoSlug?: string,
-branch?: string): string,
-
-/**
- * Downloads a file's contents via the GitHub API. You'll want to use
- * this instead of \`fs.readFile\` when aiming to support working with Peril.
- * @param {string} path The path fo the file that exists
- * @param {string} repoSlug An optional reference to the repo's slug: e.g. danger/danger-js
- * @param {string} ref An optional reference to a branch/sha
- */
-fileContents(path: string, repoSlug?: string, ref?: string): Promise<string>
-} 
-	
-/**
- * This is \`danger.github.issue\` It refers to the issue that makes up the Pull Request.
- * GitHub treats all pull requests as a special type of issue. This DSL contains only parts of the issue that are
- * not found in the PR DSL, however it does contain the full JSON structure.
- * 
- * A GitHub Issue
- */
-declare interface GitHubIssue {
-
-/**
- * The labels associated with this issue
- */
-labels: GitHubIssueLabel[]
-} 
-	declare interface GitHubIssueLabel {
-
-/**
- * The identifying number of this label
- */
-id: number,
-
-/**
- * The URL that links to this label
- */
-url: string,
-
-/**
- * The name of the label
- */
-name: string,
-
-/**
- * The color associated with this label
- */
-color: string
-} 
-	
-/**
- * An exact copy of the PR's reference JSON. This interface has type'd the majority
- * of it for tooling's sake, but any extra metadata which GitHub send will still be
- * inside the JS object.
- */
-declare interface GitHubPRDSL {
-
-/**
- * The UUID for the PR
- */
-number: number,
-
-/**
- * The state for the PR
- */
-state: \\"closed\\" | \\"open\\" | \\"locked\\" | \\"merged\\",
-
-/**
- * Has the PR been locked to contributors only?
- */
-locked: boolean,
-
-/**
- * The title of the PR
- */
-title: string,
-
-/**
- * The markdown body message of the PR
- */
-body: string,
-
-/**
- * ISO6801 Date string for when PR was created
- */
-created_at: string,
-
-/**
- * ISO6801 Date string for when PR was updated
- */
-updated_at: string,
-
-/**
- * optional ISO6801 Date string for when PR was closed
- */
-closed_at: string | null,
-
-/**
- * Optional ISO6801 Date string for when PR was merged.
- * Danger probably shouldn't be running in this state.
- */
-merged_at: string | null,
-
-/**
- * Merge reference for the _other_ repo.
- */
-head: GitHubMergeRef,
-
-/**
- * Merge reference for _this_ repo.
- */
-base: GitHubMergeRef,
-
-/**
- * The User who submitted the PR
- */
-user: GitHubUser,
-
-/**
- * The User who is assigned the PR
- */
-assignee: GitHubUser,
-
-/**
- * The Users who are assigned to the PR
- */
-assignees: GitHubUser[],
-
-/**
- * Has the PR been merged yet?
- */
-merged: boolean,
-
-/**
- * The number of comments on the PR
- */
-comments: number,
-
-/**
- * The number of review-specific comments on the PR
- */
-review_comments: number,
-
-/**
- * The number of commits in the PR
- */
-commits: number,
-
-/**
- * The number of additional lines in the PR
- */
-additions: number,
-
-/**
- * The number of deleted lines in the PR
- */
-deletions: number,
-
-/**
- * The number of changed files in the PR
- */
-changed_files: number
-} 
-	
-/**
- * A GitHub specific implmentation of a git commit, it has GitHub user names instead of an email.
- */
-declare interface GitHubCommit {
-
-/**
- * The raw commit metadata
- */
-commit: GitCommit,
-
-/**
- * The SHA for the commit
- */
-sha: string,
-
-/**
- * the url for the commit on GitHub
- */
-url: string,
-
-/**
- * The GitHub user who wrote the code
- */
-author: GitHubUser,
-
-/**
- * The GitHub user who shipped the code
- */
-committer: GitHubUser,
-
-/**
- * An array of parent commit shas
- */
-parents: any[]
-} 
-	
-/**
- * A GitHub user account.
- */
-declare interface GitHubUser {
-
-/**
- * Generic UUID
- */
-id: number,
-
-/**
- * The handle for the user/org
- */
-login: string,
-
-/**
- * Whether the user is an org, or a user
- */
-type: \\"User\\" | \\"Organization\\",
-
-/**
- * The url for a users's image
- */
-avatar_url: string
-} 
-	
-/**
- * A GitHub Repo
- */
-declare interface GitHubRepo {
-
-/**
- * Generic UUID
- */
-id: number,
-
-/**
- * The name of the repo, e.g. \\"Danger-JS\\"
- */
-name: string,
-
-/**
- * The full name of the owner + repo, e.g. \\"Danger/Danger-JS\\"
- */
-full_name: string,
-
-/**
- * The owner of the repo
- */
-owner: GitHubUser,
-
-/**
- * Is the repo publicly accessible?
- */
-private: boolean,
-
-/**
- * The textual description of the repo
- */
-description: string,
-
-/**
- * Is the repo a fork?
- */
-fork: boolean,
-
-/**
- * Is someone assigned to this PR?
- */
-assignee: GitHubUser,
-
-/**
- * Are there people assigned to this PR?
- */
-assignees: GitHubUser[],
-
-/**
- * The root web URL for the repo, e.g. https://github.com/artsy/emission
- */
-html_url: string
-} 
-	declare interface GitHubMergeRef {
-
-/**
- * The human display name for the merge reference, e.g. \\"artsy:master\\"
- */
-label: string,
-
-/**
- * The reference point for the merge, e.g. \\"master\\"
- */
-ref: string,
-
-/**
- * The reference point for the merge, e.g. \\"704dc55988c6996f69b6873c2424be7d1de67bbe\\"
- */
-sha: string,
-
-/**
- * The user that owns the merge reference e.g. \\"artsy\\"
- */
-user: GitHubUser,
-
-/**
- * The repo from whch the reference comes from
- */
-repo: GitHubRepo
-} 
-	
-/**
- * GitHubReview
- * While a review is pending, it will only have a user.  Once a review is complete, the rest of
- * the review attributes will be present
- * @export
- * @interface GitHubReview
- */
-declare interface GitHubReview {
-
-/**
- * The user requested to review, or the user who has completed the review
- */
-user: GitHubUser,
-
-/**
- * If there is a review, this provides the ID for it
- */
-id?: number,
-
-/**
- * If there is a review, the body of the review
- */
-body?: string,
-
-/**
- * If there is a review, the commit ID this review was made on
- */
-commit_id?: string,
-
-/**
- * The state of the review
- * APPROVED, REQUEST_CHANGES, COMMENT or PENDING
- */
-state?: \\"APPROVED\\" | \\"REQUEST_CHANGES\\" | \\"COMMENT\\" | \\"PENDING\\"
-} 
-	
-/**
- * Provides the current PR in an easily used way for params in \`github.api\` calls
- */
-declare interface GitHubAPIPR {
-
-/**
- * The repo owner
- */
-owner: string,
-
-/**
- * The repo name
- */
-repo: string,
-
-/**
- * The PR number
- */
-number: number
-} 
-	
-/**
- * The result of user doing warn, message or fail, built this way for
- * expansion later.
- */
-declare interface Violation {
-
-/**
- * The string representation
- */
-message: string
-} 
-	
-/**
- * Describes the possible arguments that
- * could be used when calling the CLI
- */
-declare interface CliArgs {
-base: string,
-verbose: string,
-externalCiProvider: string,
-textOnly: string,
-dangerfile: string,
-id: string
-} 
-	
-/**
- * A function with a callback function, which Danger wraps in a Promise
- */
-declare type CallbackableFn = (callback: (done: any) => void) => void;
-	
-/**
- * Types of things which Danger will schedule for you, it's recommended that you
- * just throw in an \`async () => { [...] }\` function. Can also handle a function
- * that has a single 'done' arg.
- */
-declare type Scheduleable = Promise<any> | Promise<void> | CallbackableFn;
-	
-/**
- * A Dangerfile, in Peril, is evaluated as a script, and so async code does not work
- * out of the box. By using the \`schedule\` function you can now register a
- * section of code to evaluate across multiple tick cycles.
- * 
- * \`schedule\` currently handles two types of arguments, either a promise or a function with a resolve arg.
- * @param {Function} asyncFunction the function to run asynchronously
- */
-declare function schedule(asyncFunction: Scheduleable): void
-
-	
-/**
- * Fails a build, outputting a specific reason for failing into a HTML table.
- * @param {MarkdownString} message the String to output
- */
-declare function fail(message: MarkdownString): void
-
-	
-/**
- * Highlights low-priority issues, but does not fail the build. Message
- * is shown inside a HTML table.
- * @param {MarkdownString} message the String to output
- */
-declare function warn(message: MarkdownString): void
-
-	
-/**
- * Adds a message to the Danger table, the only difference between this
- * and warn is the emoji which shows in the table.
- * @param {MarkdownString} message the String to output
- */
-declare function message(message: MarkdownString): void
-
-	
-/**
- * Adds raw markdown into the Danger comment, under the table
- * @param {MarkdownString} message the String to output
- */
-declare function markdown(message: MarkdownString): void
-
-	
-/**
- * The root Danger object. This contains all of the metadata you
- * will be looking for in order to generate useful rules.
- */
-declare var danger: DangerDSLType;
-	
-/**
- * When Peril is running your Dangerfile, the Danger DSL is
- * extended with additional options.
- */
-declare var peril: PerilDSL;
-	
-/**
- * The current results of a Danger run, this can be useful if you
- * are wanting to introspect on whether a build has already failed.
- */
-declare var results: DangerRuntimeContainer;
-    }
 "
 `;

--- a/src/cli/__tests__/compiler.spec.js
+++ b/src/cli/__tests__/compiler.spec.js
@@ -1,5 +1,6 @@
 /* @flow */
 import compiler from "../compiler";
+import beautify from "../beautifier";
 
 it("should handle maybe & nullable type", () => {
   const result = compiler.compileDefinitionString(
@@ -20,5 +21,5 @@ it("should handle bounded polymorphism", () => {
 
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
-  expect(result).toMatchSnapshot();
+  expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/cli/__tests__/fixtures.spec.js
+++ b/src/cli/__tests__/fixtures.spec.js
@@ -1,5 +1,5 @@
 /* @flow */
-import compiler from "../compiler";
+import { compiler, beautify } from "../compiler";
 import fs from "fs";
 
 it("handles the danger.d.ts correctly", () => {
@@ -9,5 +9,5 @@ it("handles the danger.d.ts correctly", () => {
   );
   const result = compiler.compileDefinitionString(dangerDTS, { quiet: true });
 
-  expect(result).toMatchSnapshot();
+  expect(beautify(result)).toMatchSnapshot();
 });

--- a/src/cli/__tests__/fixtures.spec.js
+++ b/src/cli/__tests__/fixtures.spec.js
@@ -1,5 +1,6 @@
 /* @flow */
-import { compiler, beautify } from "../compiler";
+import compiler from "../compiler";
+import beautify from "../beautifier";
 import fs from "fs";
 
 it("handles the danger.d.ts correctly", () => {

--- a/src/cli/beautifier.js
+++ b/src/cli/beautifier.js
@@ -2,5 +2,5 @@
 import prettier from "prettier";
 
 export default function beautify(str: string): string {
-  return prettier.format(str, { parser: "flow" });
+  return prettier.format(str, { parser: "babel-flow" });
 }

--- a/src/cli/compiler.js
+++ b/src/cli/compiler.js
@@ -95,7 +95,14 @@ export default {
     return compile.withEnv({})(sourceFile);
   },
 
-  compileDefinitionFile: (path: string, options?: Options): string => {
+  compileDefinitionFile: (
+    path: string,
+    options?: Options,
+    mapSourceCode?: (
+      source: string | void,
+      fileName: string,
+    ) => string | void = a => a,
+  ): string => {
     reset(options);
 
     const compilerOptions = {
@@ -104,6 +111,9 @@ export default {
     };
     const compilerHost = createCompilerHost({}, true);
     const oldSourceFile = compilerHost.getSourceFile;
+    const oldReadFile = compilerHost.readFile;
+    compilerHost.readFile = fileName =>
+      mapSourceCode(oldReadFile(fileName), fileName);
     compilerHost.getSourceFile = (file, languageVersion) => {
       if (file === path) {
         return transform(
@@ -136,6 +146,10 @@ export default {
   compileDefinitionFiles: (
     paths: string[],
     options?: Options,
+    mapSourceCode?: (
+      source: string | void,
+      fileName: string,
+    ) => string | void = a => a,
   ): Array<[string, string]> => {
     const compilerOptions = {
       noLib: true,
@@ -143,6 +157,9 @@ export default {
     };
     const compilerHost = createCompilerHost({}, true);
     const oldSourceFile = compilerHost.getSourceFile;
+    const oldReadFile = compilerHost.readFile;
+    compilerHost.readFile = fileName =>
+      mapSourceCode(oldReadFile(fileName), fileName);
     compilerHost.getSourceFile = (file, languageVersion) => {
       if (paths.includes(file)) {
         return transform(

--- a/src/cli/default-exporter.js
+++ b/src/cli/default-exporter.js
@@ -19,6 +19,7 @@ const writeFile: (fd: number, output: string) => Promise<void> = promisify(
 export default async function exportDefault(
   fileName: string,
   output: string,
+  _index: number,
 ): Promise<string> {
   const folderName = path.dirname(fileName);
   let handle;

--- a/src/cli/flow-typed-exporter.js
+++ b/src/cli/flow-typed-exporter.js
@@ -2,17 +2,24 @@
 
 import fs from "fs";
 import shell from "shelljs";
+import path from "path";
 import program from "commander";
 import { promisify } from "./util";
+
+import type { DirectoryFlowTypedFile } from "./runner.h";
 
 const exists: (filename: string) => Promise<boolean> = promisify(fs.exists);
 const writeFile: (filename: string, data: string) => Promise<void> = promisify(
   fs.writeFile,
 );
+const appendFile: (filename: string, data: string) => Promise<void> = promisify(
+  fs.appendFile,
+);
 
-export default async function exportForFlowTyped(
+export async function flowTypedExporter(
   moduleName: string,
   output: string,
+  _index: number,
 ): Promise<string> {
   const opts = program.opts();
   const out =
@@ -28,5 +35,29 @@ export default async function exportForFlowTyped(
   }
   await writeFile(testfilePath, "");
   await writeFile(outputFile, output);
+  return testfilePath;
+}
+
+export async function flowTypedDirectoryExporter(
+  { rootModuleName }: DirectoryFlowTypedFile,
+  output: string,
+  index: number,
+): Promise<string> {
+  const opts = program.opts();
+  const out =
+    typeof opts.flowTypedFormat === "string" ? opts.flowTypedFormat : "exports";
+  const flowFolder = `${out}/flow_v0.35.x-`;
+  const outputFile = `${out}/flow_v0.35.x-/${rootModuleName}.js`;
+
+  const testfilePath = `${out}/test_${rootModuleName}.js`;
+
+  if (!(await exists(flowFolder))) {
+    shell.mkdir("-p", flowFolder);
+  }
+  if (index === 0 && (await exists(outputFile))) {
+    await writeFile(outputFile, "");
+  }
+  await writeFile(testfilePath, "");
+  await appendFile(outputFile, output);
   return testfilePath;
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -19,6 +19,7 @@ program
   )
   .option("--quiet", "output without logs")
   .option("--no-jsdoc", "output without jsdoc")
+  .option("--no-inexact", "output without inexact types")
   .option("--flow-typed-format [dirname]", "format output for flow-typed")
   .option(
     "--add-flow-header",
@@ -32,6 +33,7 @@ program
       moduleExports: options.moduleExports,
       jsdoc: options.jsdoc,
       quiet: options.quiet,
+      inexact: options.inexact,
       flowTypedFormat: options.flowTypedFormat,
       addFlowHeader: options.addFlowHeader,
       compileTests: options.compileTests,

--- a/src/cli/runner.h.js
+++ b/src/cli/runner.h.js
@@ -1,0 +1,34 @@
+// @flow
+
+export type RunnerOptions = {
+  jsdoc: boolean,
+  quiet: boolean,
+  interfaceRecords: boolean,
+  moduleExports: boolean,
+  inexact: boolean,
+  version: string,
+  out: string,
+  flowTypedFormat: boolean,
+  addFlowHeader: boolean,
+  compileTests: boolean,
+  ...
+};
+
+export type Mode = "directory" | "directory-flow-typed" | "flow-typed" | "file";
+
+export type DirectoryFlowTypedFile = {|
+  rootModuleName: string,
+  moduleName: string,
+  filename: string,
+|};
+export type OutputFile = DirectoryFlowTypedFile | string;
+
+export type File = {|
+  index: number,
+  mode: Mode,
+  moduleName: string,
+  isMain: boolean,
+  file: string,
+  +outputFile: OutputFile,
+  intro: string,
+|};

--- a/src/errors/error-message.js
+++ b/src/errors/error-message.js
@@ -17,6 +17,9 @@ export type ErrorMessage =
       +type: "UnsupportedGlobalAugmentation",
     |}
   | {|
+      +type: "UnsupportedNestedModule",
+    |}
+  | {|
       +type: "MissingFunctionName",
     |};
 
@@ -39,6 +42,9 @@ export function printErrorMessage(error: ErrorMessage): string {
 
     case "UnsupportedGlobalAugmentation":
       return "Flow doesn't support global augmentation";
+
+    case "UnsupportedNestedModule":
+        return "Flow doesn't support nested modules";
 
     default:
       (error.type: empty);

--- a/src/errors/error-message.js
+++ b/src/errors/error-message.js
@@ -1,5 +1,7 @@
 // @flow
 
+import {SyntaxKind} from 'typescript'
+
 export type ErrorMessage =
   | {|
       +type: "UnsupportedComputedProperty",
@@ -18,6 +20,10 @@ export type ErrorMessage =
     |}
   | {|
       +type: "UnsupportedNestedModule",
+    |}
+  | {|
+      +type: "UnsupportedTypeOperator",
+      +operator: $Values<typeof SyntaxKind>
     |}
   | {|
       +type: "MissingFunctionName",
@@ -45,6 +51,9 @@ export function printErrorMessage(error: ErrorMessage): string {
 
     case "UnsupportedNestedModule":
         return "Flow doesn't support nested modules";
+
+    case "UnsupportedTypeOperator":
+        return `Unsupported type operator: ${SyntaxKind[error.operator]}`
 
     default:
       (error.type: empty);

--- a/src/nodes/factory.js
+++ b/src/nodes/factory.js
@@ -29,12 +29,12 @@ export class Factory {
 
   // If multiple declarations are found for the same module name
   // return the memoized instance of the module instead
-  createModuleNode(name: string): ModuleNode {
+  createModuleNode(node: RawNode, name: string): ModuleNode {
     if (Object.keys(this._modules).includes(name)) {
       return this._modules[name];
     }
 
-    const module = new ModuleNode(name);
+    const module = new ModuleNode(node, name);
 
     this._modules[name] = module;
 

--- a/src/nodes/namespace.js
+++ b/src/nodes/namespace.js
@@ -116,7 +116,7 @@ export default class Namespace extends Node {
     ) {
       let topLevel = "";
       const nsGroup = `
-      declare var npm$namespace$${name}: {
+      declare var npm$namespace$${name}: {|
         ${this.functions
           .map(
             propNode =>
@@ -148,7 +148,7 @@ export default class Namespace extends Node {
             return `${child.name}: typeof npm$namespace$${name}$${child.name},`;
           })
           .join("\n")}
-      }\n`;
+      |}\n`;
       if (namespace === "") {
         topLevel = `declare var ${name}: typeof npm$namespace$${name};\n`;
       }

--- a/src/nodes/namespace.js
+++ b/src/nodes/namespace.js
@@ -69,7 +69,7 @@ export default class Namespace extends Node {
     }
   }
 
-  print = (namespace: string = "", mod: string = "root"): string => {
+  print = (namespace: string = "", mod: string = "root", depth?: number): string => {
     const children = uniqBy(
       orderBy(this.getChildren(), [a => a.isValue], ["desc"]),
       child => child.name.text || child.name,
@@ -102,7 +102,7 @@ export default class Namespace extends Node {
 
     const childrenNode = `${this.getChildren()
       .map(child => {
-        return child.print(name, mod);
+        return child.print(name, mod, depth);
       })
       .join("\n\n")}`;
 

--- a/src/nodes/node.js
+++ b/src/nodes/node.js
@@ -68,7 +68,7 @@ export default class Node<NodeType = RawNode> {
   }
 
   //eslint-disable-next-line
-  print(namespace?: string, module?: string): string {
+  print(namespace?: string, module?: string, depth?: number): string {
     return printers.node.printType(this.raw);
   }
 }

--- a/src/options.js
+++ b/src/options.js
@@ -5,6 +5,7 @@ export type Options = {|
   interfaceRecords?: boolean,
   moduleExports?: boolean,
   quiet?: boolean,
+  inexact?: boolean,
 |};
 
 const defaultOptions: Options = Object.freeze({
@@ -12,6 +13,7 @@ const defaultOptions: Options = Object.freeze({
   interfaceRecords: false,
   moduleExports: true,
   quiet: false,
+  inexact: true,
 });
 
 let options: Options = { ...defaultOptions };

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -27,7 +27,10 @@ const collectNode = (
           ts.NodeFlags.GlobalAugmentation
         ) {
           logger.error(node, { type: "UnsupportedGlobalAugmentation" });
-          const globalAugmentation = factory.createModuleNode(node.name.text);
+          const globalAugmentation = factory.createModuleNode(
+            node,
+            node.name.text,
+          );
           context.addChild("module" + node.name.text, globalAugmentation);
           traverseNode(node.body, globalAugmentation, factory);
           break;
@@ -45,7 +48,7 @@ const collectNode = (
         context.addChildren("namespace" + node.name.text, namespace);
         break;
       } else {
-        const module = factory.createModuleNode(node.name.text);
+        const module = factory.createModuleNode(node, node.name.text);
 
         context.addChild("module" + node.name.text, module);
 
@@ -140,7 +143,7 @@ const traverseNode = (node, context: Node<>, factory: Factory): void => {
 export function recursiveWalkTree(ast: any): ModuleNode {
   const factory = NodeFactory.create();
 
-  const root = factory.createModuleNode("root");
+  const root = factory.createModuleNode(null, "root");
 
   traverseNode(ast, root, factory);
 

--- a/src/printers/declarations.js
+++ b/src/printers/declarations.js
@@ -73,31 +73,34 @@ export const variableDeclaration = (node: RawNode): string => {
 export const interfaceType = (
   node: RawNode,
   withSemicolons: boolean = false,
+  isType: boolean = false,
 ): string => {
-  let members = node.members
-    .map(member => {
-      const printed = printers.node.printType(member);
+  const isInexact = opts().inexact;
+  let members = node.members.map(member => {
+    const printed = printers.node.printType(member);
 
-      if (!printed) {
-        return null;
-      }
+    if (!printed) {
+      return null;
+    }
 
-      let str = "\n";
+    let str = "\n";
 
-      if (member.jsDoc) {
-        str += printers.common.comment(member.jsDoc);
-      }
+    if (member.jsDoc) {
+      str += printers.common.comment(member.jsDoc);
+    }
 
-      return str + printed;
-    })
-    .filter(Boolean) // Filter rows which didnt print propely (private fields et al)
-    .join(withSemicolons ? ";" : ",");
+    return str + printed;
+  });
 
-  if (members.length > 0) {
-    members += "\n";
+  if (isType && isInexact) {
+    members.push("...\n");
+  } else if (members.length > 0) {
+    members.push("\n");
   }
 
-  return `{${members}}`;
+  return `{${members
+    .filter(Boolean) // Filter rows which didnt print propely (private fields et al)
+    .join(withSemicolons ? ";" : ",")}}`;
 };
 
 const interfaceRecordType = (
@@ -222,7 +225,11 @@ export const interfaceDeclaration = (
 
   let str = `${modifier}${type} ${nodeName}${printers.common.generics(
     node.typeParameters,
-  )} ${type === "type" ? "= " : ""}${interfaceType(node)} ${heritage}`;
+  )} ${type === "type" ? "= " : ""}${interfaceType(
+    node,
+    false,
+    type === "type",
+  )} ${heritage}`;
 
   return str;
 };

--- a/src/printers/identifiers.js
+++ b/src/printers/identifiers.js
@@ -3,6 +3,7 @@
 // Please add only built-in type references
 
 import printers from "./index";
+import { opts } from "../options";
 import { withEnv } from "../env";
 
 const identifiers = Object.create(null);
@@ -13,17 +14,22 @@ Object.assign(identifiers, {
   Readonly: "$ReadOnly",
   NonNullable: "$NonMaybeType",
   Partial: ([type]: any[]) => {
-    return `$Rest<${printers.node.printType(type)}, {}>`;
+    const isInexact = opts().inexact;
+    return `$Rest<${printers.node.printType(type)}, {${
+      isInexact ? "..." : ""
+    }}>`;
   },
   ReturnType: (typeArguments: any[]) => {
     return `$Call<<R>((...args: any[]) => R) => R, ${printers.node.printType(
       typeArguments[0],
     )}>`;
   },
-  Record: ([key, value]: [any, any]) =>
-    `{[key: ${printers.node.printType(key)}]: ${printers.node.printType(
+  Record: ([key, value]: [any, any]) => {
+    const isInexact = opts().inexact;
+    return `{[key: ${printers.node.printType(key)}]: ${printers.node.printType(
       value,
-    )}}`,
+    )}${isInexact ? ", ..." : ""}}`;
+  },
 });
 
 export const print = withEnv<any, [string], string>(

--- a/src/printers/identifiers.js
+++ b/src/printers/identifiers.js
@@ -3,6 +3,7 @@
 // Please add only built-in type references
 
 import printers from "./index";
+import { withEnv } from "../env";
 
 const identifiers = Object.create(null);
 Object.assign(identifiers, {
@@ -25,6 +26,9 @@ Object.assign(identifiers, {
     )}}`,
 });
 
-export const print = (kind: string): string => {
-  return identifiers[kind] || kind;
-};
+export const print = withEnv<any, [string], string>(
+  (env, kind: string): string => {
+    if (env.classHeritage) return kind;
+    return identifiers[kind] || kind;
+  },
+);

--- a/src/printers/index.js.flow
+++ b/src/printers/index.js.flow
@@ -14,7 +14,7 @@ declare export default {|
   declarations: {|
     propertyDeclaration(node: RawNode, keywordPrefix: string): string,
     variableDeclaration(node: RawNode): string,
-    interfaceType(node: RawNode, withSemicolons?: boolean): string,
+    interfaceType(node: RawNode, withSemicolons?: boolean, isType?: boolean): string,
     interfaceDeclaration(
       nodeName: string,
       node: RawNode,

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -434,7 +434,7 @@ export const printType = withEnv<any, [any], string>(
         return printers.functions.functionType(type);
 
       case ts.SyntaxKind.TypeLiteral:
-        return printers.declarations.interfaceType(type);
+        return printers.declarations.interfaceType(type, false, true);
 
       //case SyntaxKind.IdentifierObject:
       //case SyntaxKind.StringLiteralType:

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -521,6 +521,9 @@ export const printType = withEnv<any, [any], string>(
         return type.text;
 
       case ts.SyntaxKind.ImportType:
+        if (type.qualifier?.escapedText) {
+          return `$PropertyType<$Exports<${printType(type.argument)}>, ${JSON.stringify(type.qualifier.escapedText)}>`;
+        }
         return `$Exports<${printType(type.argument)}>`;
 
       case ts.SyntaxKind.FirstTypeNode:

--- a/src/printers/node.js
+++ b/src/printers/node.js
@@ -483,15 +483,27 @@ export const printType = withEnv<any, [any], string>(
           case ts.SyntaxKind.UniqueKeyword:
             logger.error(type, { type: "UnsupportedUniqueSymbol" });
             return printType(type.type);
-          default:
-            console.log(
-              `"NO PRINT IMPLEMENTED: TypeOperator ${
-                ts.SyntaxKind[type.operator]
-              }"`,
-            );
-            return `"NO PRINT IMPLEMENTED: TypeOperator ${
-              ts.SyntaxKind[type.operator]
-            }"`;
+          case ts.SyntaxKind.ReadonlyKeyword:
+            if (type.type.kind === ts.SyntaxKind.ArrayType) {
+              return `$ReadOnlyArray<${printType(type.type.elementType)}>`;
+            } else if (type.type.kind === ts.SyntaxKind.TupleType) {
+              return printType(type.type);
+            } else {
+              const error = {
+                type: "UnsupportedTypeOperator",
+                operator: type.operator,
+              };
+              logger.error(type, error);
+              return `/* ${printErrorMessage(error)} */ any`;
+            }
+          default: {
+            const error = {
+              type: "UnsupportedTypeOperator",
+              operator: type.operator,
+            };
+            logger.error(type, error);
+            return `/* ${printErrorMessage(error)} */ any`;
+          }
         }
 
       case ts.SyntaxKind.MappedType: {


### PR DESCRIPTION
- `--inexact` option is `true` by default, would make all generated types explicit inexact (not interfaces), to disable use `--no-inexact`
- `directory-flow-typed` mode is basically overhaul of all flow-typed export, that I plan to somehow intergrate in flow-typed, not sure how it would work with `create-stub`, currently it just would live here
- Class heritage fix ignores transforms in class `mixins`, and `extends` so we don't get `declare class A extends Partial<T> {}` converted to `declare class A extends $Rest<T, {}> {}`