### PR TITLE
bugfix: fix declaration files

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,8 @@ export type Options = {
   jsdoc?: boolean;
   interfaceRecords?: boolean;
   moduleExports?: boolean;
+  quiet?: boolean;
+  inexact?: boolean;
 };
 
 export type Compiler = {
@@ -30,4 +32,6 @@ type Flowgen = {
   compiler: Compiler;
 };
 
-export default Flowgen;
+export declare const flowgen: Flowgen;
+
+export default flowgen;

--- a/index.js.flow
+++ b/index.js.flow
@@ -4,6 +4,8 @@ export type Options = {|
   jsdoc?: boolean,
   interfaceRecords?: boolean,
   moduleExports?: boolean,
+  quiet?: boolean,
+  inexact?: boolean,
 |};
 
 export type Compiler = {|
@@ -30,4 +32,6 @@ declare type Flowgen = {|
   compiler: Compiler,
 |};
 
-declare export default Flowgen;
+declare export const flowgen: Flowgen;
+
+declare export default flowgen;


### PR DESCRIPTION
I noticed when using flowgen with typescript that the declarations were broken and the options incomplete.