### PR TITLE
Export non-generic interfaces through namespaces

### DIFF
--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -62,6 +62,8 @@ exports[`should handle merging with other types function interface 1`] = `
 
 declare var npm$namespace$test: {|
   (foo: number): string,
+
+  Foo: Class<test$Foo>,
 |};
 export interface test$Foo {
   bar: number;
@@ -131,6 +133,7 @@ declare type E0$A = external.type;
 declare var npm$namespace$E0$U1: {|
   e2: typeof E0$U1$e2,
   E2: typeof E0$U1$E2,
+  S3: Class<E0$U1$S3>,
 
   D1: typeof npm$namespace$E0$U1$D1,
   DD1: typeof npm$namespace$E0$U1$DD1,
@@ -153,6 +156,7 @@ declare var npm$namespace$E0$U1$D1: {|
 declare var npm$namespace$E0$U1$D1$S2: {|
   n3: typeof E0$U1$D1$S2$n3,
 
+  S3: Class<E0$U1$D1$S2$S3>,
   N3: typeof E0$U1$D1$S2$N3,
 |};
 declare interface E0$U1$D1$S2$S3 {

--- a/src/nodes/namespace.ts
+++ b/src/nodes/namespace.ts
@@ -88,6 +88,13 @@ export default class Namespace extends Node {
     const enums = children.filter(
       child => child.raw && child.raw.kind === ts.SyntaxKind.EnumDeclaration,
     );
+    // Interfaces with type parameters are not expressible inside namespaces.
+    const interfaces = children.filter(
+      child =>
+        child.raw &&
+        child.raw.kind === ts.SyntaxKind.InterfaceDeclaration &&
+        !(child.raw.typeParameters && child.raw.typeParameters.length),
+    );
     const classes = children.filter(
       child => child.raw && child.raw.kind === ts.SyntaxKind.ClassDeclaration,
     );
@@ -135,6 +142,11 @@ export default class Namespace extends Node {
         ${enums
           .map(child => {
             return `${child.name}: typeof ${name}$${child.name},`;
+          })
+          .join("\n")}
+        ${interfaces
+          .map(child => {
+            return `${child.name}: Class<${name}$${child.name}>,`;
           })
           .join("\n")}
         ${classes


### PR DESCRIPTION
This change also exposes interfaces through namespace `var`. This allows
them to be accessed by name. This is only done when the interface is
non-generic, since generic interfaces cannot be expressed in a `var`.