### PR TITLE
Allow interface records to be exact, too

### DIFF
--- a/src/__tests__/__snapshots__/interfaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.ts.snap
@@ -33,6 +33,18 @@ declare type SpecialUser = {
 "
 `;
 
+exports[`should handle interface inheritance 3`] = `
+"declare type User = {|
+  firstName: string,
+|};
+declare type SpecialUser = {|
+  ...$Exact<User>,
+
+  nice: number,
+|};
+"
+`;
+
 exports[`should handle interface merging 1`] = `
 "declare interface User {
   firstName: string;

--- a/src/__tests__/interfaces.spec.ts
+++ b/src/__tests__/interfaces.spec.ts
@@ -29,6 +29,11 @@ interface SpecialUser extends User {
     interfaceRecords: true,
   });
   expect(beautify(result2)).toMatchSnapshot();
+  const result3 = compiler.compileDefinitionString(ts, {
+    interfaceRecords: true,
+    inexact: false,
+  });
+  expect(beautify(result3)).toMatchSnapshot();
 });
 
 it("should handle interface merging", () => {

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -106,6 +106,7 @@ const interfaceRecordType = (
   heritage: string,
   withSemicolons = false,
 ): string => {
+  const isInexact = opts().inexact;
   let members = node.members
     .map(member => {
       const printed = printers.node.printType(member);
@@ -129,7 +130,11 @@ const interfaceRecordType = (
     members += "\n";
   }
 
-  return `{${heritage}${members}}`;
+  if (isInexact) {
+    return `{${heritage}${members}}`;
+  } else {
+    return `{|${heritage}${members}|}`;
+  }
 };
 
 const classHeritageClause = withEnv<any, any, string>((env, type) => {


### PR DESCRIPTION
This change makes interface records to be exact using `{| ... |}` when
the `--no-inexact` flag is passed.