### PR TITLE
Class-namespace merging

### DIFF
--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -20,12 +20,9 @@ exports[`should handle import equals declaration 1`] = `
 exports[`should handle merging with other types class 1`] = `
 "declare class Album {
   label: Album$AlbumLabel;
+  static AlbumLabel: typeof Album$AlbumLabel;
 }
-declare var Album: typeof npm$namespace$Album;
 
-declare var npm$namespace$Album: {|
-  AlbumLabel: typeof Album$AlbumLabel,
-|};
 declare export class Album$AlbumLabel {}
 "
 `;
@@ -50,7 +47,6 @@ exports[`should handle merging with other types function const 1`] = `
 
 declare var npm$namespace$test: {|
   (foo: number): string,
-
   ok: typeof test$ok,
 |};
 declare export var test$ok: number;
@@ -62,7 +58,6 @@ exports[`should handle merging with other types function interface 1`] = `
 
 declare var npm$namespace$test: {|
   (foo: number): string,
-
   Foo: Class<test$Foo>,
 |};
 export interface test$Foo {
@@ -119,13 +114,98 @@ declare export var test$ok: number;
 "
 `;
 
+exports[`should handle nested namespace merging class 1`] = `
+"declare var ns: typeof npm$namespace$ns;
+
+declare var npm$namespace$ns: {|
+  Album: typeof npm$namespace$ns$Album,
+|};
+declare class ns$Album {
+  label: Album$AlbumLabel;
+}
+
+declare var npm$namespace$ns$Album: {|
+  AlbumLabel: typeof ns$Album$AlbumLabel,
+|};
+declare export class ns$Album$AlbumLabel {}
+"
+`;
+
+exports[`should handle nested namespace merging enum 1`] = `
+"declare var ns: typeof npm$namespace$ns;
+
+declare var npm$namespace$ns: {|
+  Color: typeof npm$namespace$ns$Color,
+|};
+
+declare var ns$Color: {|
+  +red: 1, // 1
+  +green: 2, // 2
+  +blue: 4, // 4
+|};
+
+declare var npm$namespace$ns$Color: {|
+  mixColor: typeof ns$Color$mixColor,
+|};
+declare export function ns$Color$mixColor(colorName: string): number;
+"
+`;
+
+exports[`should handle nested namespace merging function const 1`] = `
+"declare var ns: typeof npm$namespace$ns;
+
+declare var npm$namespace$ns: {|
+  test: typeof npm$namespace$ns$test,
+|};
+
+declare var npm$namespace$ns$test: {|
+  (foo: number): string,
+  ok: typeof ns$test$ok,
+|};
+declare export var test$ok: number;
+"
+`;
+
+exports[`should handle nested namespace merging function interface 1`] = `
+"declare var ns: typeof npm$namespace$ns;
+
+declare var npm$namespace$ns: {|
+  test: typeof ns$test,
+|};
+
+declare var npm$namespace$ns$test: {|
+  (foo: number): string,
+  Foo: Class<ns$test$Foo>,
+|};
+export interface ns$test$Foo {
+  bar: number;
+}
+"
+`;
+
+exports[`should handle nested namespace merging function type 1`] = `
+"declare var ns: typeof npm$namespace$ns;
+
+declare var npm$namespace$ns: {|
+  test: typeof ns$test,
+|};
+
+declare var npm$namespace$ns$test: {|
+  (foo: number): string,
+|};
+export type ns$test$Foo = {
+  bar: number,
+  ...
+};
+"
+`;
+
 exports[`should handle nested namespaces 1`] = `
 "import * as external from \\"external\\";
 declare var E0: typeof npm$namespace$E0;
 
 declare var npm$namespace$E0: {|
   s1: typeof E0$s1,
-
   S1: typeof npm$namespace$E0$S1,
 |};
 declare type E0$A = external.type;
@@ -134,7 +214,6 @@ declare var npm$namespace$E0$U1: {|
   e2: typeof E0$U1$e2,
   E2: typeof E0$U1$E2,
   S3: Class<E0$U1$S3>,
-
   D1: typeof npm$namespace$E0$U1$D1,
   DD1: typeof npm$namespace$E0$U1$DD1,
 |};
@@ -155,7 +234,6 @@ declare var npm$namespace$E0$U1$D1: {|
 
 declare var npm$namespace$E0$U1$D1$S2: {|
   n3: typeof E0$U1$D1$S2$n3,
-
   S3: Class<E0$U1$D1$S2$S3>,
   N3: typeof E0$U1$D1$S2$N3,
 |};
@@ -167,6 +245,9 @@ declare var E0$U1$D1$S2$n3: Symbol;
 
 declare class E0$U1$D1$S2$N3 {}
 
+declare var npm$namespace$E0$U1$DD1$S2: {|
+  S3: Class<E0$U1$DD1$S2$S3>,
+|};
 declare interface E0$U1$DD1$S2$S3 {
   e: number;
 }

--- a/src/__tests__/namespaces.spec.ts
+++ b/src/__tests__/namespaces.spec.ts
@@ -46,7 +46,6 @@ namespace test {
 
   test("class", () => {
     const ts = `
-// TODO: implement class merging
 declare class Album {
   label: Album.AlbumLabel;
 }
@@ -56,7 +55,7 @@ namespace Album {
 `;
     const result = compiler.compileDefinitionString(ts);
     expect(beautify(result)).toMatchSnapshot();
-    expect(result).not.toBeValidFlowTypeDeclarations(); // TODO: prop-missing
+    expect(result).toBeValidFlowTypeDeclarations();
   });
 
   test("enum", () => {
@@ -172,6 +171,87 @@ declare namespace E0 {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
   expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-module
+});
+
+describe("should handle nested namespace merging", () => {
+  describe("function", () => {
+    test("interface", () => {
+      const ts = `
+namespace ns {
+  declare function test(foo: number): string;
+  namespace test {
+    export interface Foo {
+      bar: number
+    }
+  }
+}
+`;
+      const result = compiler.compileDefinitionString(ts);
+      expect(beautify(result)).toMatchSnapshot();
+    });
+
+    test("type", () => {
+      const ts = `
+namespace ns {
+  declare function test(foo: number): string;
+  namespace test {
+    export type Foo = {
+      bar: number
+    }
+  }
+}
+`;
+      const result = compiler.compileDefinitionString(ts);
+      expect(beautify(result)).toMatchSnapshot();
+    });
+
+    test("const", () => {
+      const ts = `
+namespace ns {
+  declare function test(foo: number): string;
+  namespace test {
+    export const ok: number
+  }
+}
+`;
+      const result = compiler.compileDefinitionString(ts);
+      expect(beautify(result)).toMatchSnapshot();
+    });
+  });
+
+  test("class", () => {
+    const ts = `
+namespace ns {
+  // TODO: implement class merging inside namespaces
+  declare class Album {
+    label: Album.AlbumLabel;
+  }
+  namespace Album {
+    export declare class AlbumLabel { }
+  }
+}
+`;
+    const result = compiler.compileDefinitionString(ts);
+    expect(beautify(result)).toMatchSnapshot();
+  });
+
+  test("enum", () => {
+    const ts = `
+namespace ns {
+  // TODO: implement enum merging inside namespaces
+  enum Color {
+    red = 1,
+    green = 2,
+    blue = 4
+  }
+  namespace Color {
+    export declare function mixColor(colorName: string): number;
+  }
+}
+`;
+    const result = compiler.compileDefinitionString(ts);
+    expect(beautify(result)).toMatchSnapshot();
+  });
 });
 
 test("should handle qualified namespaces", () => {

--- a/src/nodes/module.ts
+++ b/src/nodes/module.ts
@@ -1,6 +1,8 @@
+import * as ts from "typescript";
 import type { RawNode } from "./node";
 import * as logger from "../logger";
 import Node from "./node";
+import Namespace from "./namespace";
 
 export default class Module extends Node {
   name: string;
@@ -18,6 +20,14 @@ export default class Module extends Node {
 
   addChildren(name: string, child: Node): void {
     child.module = this.name;
+    if (
+      child instanceof Namespace &&
+      this.children[child.name] &&
+      this.children[child.name].raw &&
+      this.children[child.name].raw.kind === ts.SyntaxKind.ClassDeclaration
+    ) {
+      name = child.name;
+    }
     if (!this.children[name]) {
       this.children[name] = child;
       return;

--- a/src/nodes/property.ts
+++ b/src/nodes/property.ts
@@ -84,9 +84,22 @@ export default class Property extends Node<PropertyNode> {
       case ts.SyntaxKind.FunctionDeclaration:
         out += printers.functions.functionDeclaration(name, this.raw);
         break;
-      case ts.SyntaxKind.ClassDeclaration:
-        out += printers.declarations.classDeclaration(name, this.raw);
+      case ts.SyntaxKind.ClassDeclaration: {
+        const classChildren = this.getChildren();
+        out += printers.declarations.classDeclaration(
+          name,
+          this.raw,
+          classChildren,
+        );
+        if (classChildren.length) {
+          out += `\n\n${classChildren
+            .map(child => {
+              return child.print(name, mod);
+            })
+            .join("\n\n")}`;
+        }
         break;
+      }
       case ts.SyntaxKind.InterfaceDeclaration:
         out += printers.declarations.interfaceDeclaration(
           name,

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -483,7 +483,7 @@ export const printType = withEnv<any, [any], string>(
         return printers.functions.functionType(type);
 
       case ts.SyntaxKind.TypeLiteral:
-        return printers.declarations.interfaceType(type, false, true);
+        return printers.declarations.interfaceType(type, "", [], false, true);
 
       //case SyntaxKind.IdentifierObject:
       //case SyntaxKind.StringLiteralType:


### PR DESCRIPTION
This change implements merging classes and namespaces when they occur at
the root of a namespace. Class-namespace merging does not still occur
when they are declared in a nested namespace (that's coming in the next PR!)