### PR TITLE
Run the flow checker on all tests

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -22,8 +22,8 @@ Hey so you want to take a look at fixing your bug, we have three steps:
 From there you should add a new test file with a chunk of your TypeScript interface. For example, I created the file `src/__tests__/union_strings.spec.js` and added
 
 ```js
-import compiler from '../cli/compiler';
-import beautify from '../cli/beautifier';
+import { compiler, beautify } from "..";
+import "./matchers";
 
 it('should handle union strings', () => {
   const ts = `
@@ -33,8 +33,9 @@ it('should handle union strings', () => {
 `;
 
   const result = compiler.compileDefinitionString(ts);
-  
+
   expect(beautify(result)).toMatchSnapshot()
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.3.0",
+    "chalk": "^4.1.0",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "flow-bin": "^0.141.0",
     "jest": "^26.4.2"
   },
   "files": [
@@ -60,7 +62,8 @@
     "prepublishOnly": "npm run compile",
     "compile": "babel ./src --extensions '.ts,.tsx,.js' --out-dir lib --delete-dir-on-start --ignore 'src/**/*.spec.ts'",
     "compile:watch": "npm run compile -- -w",
-    "test": "jest",
+    "test": "jest src/**/*.spec.ts",
+    "test:watch": "jest src/**/*.spec.ts --watch",
     "lint": "eslint '**/*.{js,ts,tsx}' --quiet"
   }
 }

--- a/src/__tests__/__snapshots__/classes.spec.ts.snap
+++ b/src/__tests__/__snapshots__/classes.spec.ts.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle static methods ES6 classes 1`] = `
-"declare class Observable<T> mixins Subscribable<T> {
+"declare class Subscribable<T> {}
+declare class Operator<T, R> {}
+declare class Observable<T> mixins Subscribable<T> {
   create: Function;
   static create: Function;
   lift<R>(operator: Operator<T, R>): Observable<R>;

--- a/src/__tests__/__snapshots__/function-exports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/function-exports.spec.ts.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle default exported es module functions 1`] = `
-"declare export default function routerReducer(
+"declare class Action {}
+declare class RouterState {}
+declare export default function routerReducer(
   state?: RouterState,
   action?: Action
 ): RouterState;
@@ -9,7 +11,12 @@ exports[`should handle default exported es module functions 1`] = `
 `;
 
 exports[`should handle exported es module functions 1`] = `
-"declare export function routerReducer(
+"declare class Action {}
+declare class RouterState {}
+declare class Store<T> {}
+declare class SyncHistoryWithStoreOptions {}
+declare class HistoryUnsubscribe {}
+declare export function routerReducer(
   state?: RouterState,
   action?: Action
 ): RouterState;
@@ -22,7 +29,9 @@ declare export function syncHistoryWithStore(
 `;
 
 exports[`should handle function overload es module functions 1`] = `
-"declare export function routerReducer(
+"declare class Action {}
+declare class RouterState {}
+declare export function routerReducer(
   state?: RouterState,
   action?: Action
 ): RouterState;

--- a/src/__tests__/__snapshots__/interfaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.ts.snap
@@ -113,7 +113,8 @@ exports[`should handle untyped object binding pattern 1`] = `
 `;
 
 exports[`should remove generic defaults in call signature 1`] = `
-"declare interface AbstractLevelDOWNConstructor {
+"declare interface AbstractLevelDOWN<K, V> {}
+declare interface AbstractLevelDOWNConstructor {
   <K, V>(location: string): AbstractLevelDOWN<K, V>;
 }
 "
@@ -133,7 +134,9 @@ declare interface C<This, Datum> {
 `;
 
 exports[`should support call signature 1`] = `
-"declare interface ObjectSchemaConstructor {
+"declare interface ObjectSchema<T> {}
+declare interface ObjectSchemaDefinition<T> {}
+declare interface ObjectSchemaConstructor {
   <T: { [key: string]: any }>(
     fields?: ObjectSchemaDefinition<T>
   ): ObjectSchema<T>;

--- a/src/__tests__/__snapshots__/jsdoc.spec.ts.snap
+++ b/src/__tests__/__snapshots__/jsdoc.spec.ts.snap
@@ -47,6 +47,7 @@ declare var patchOuter: <T>(
   fn: (data: T) => void,
   data?: T
 ) => Node | null;
+declare class ECharts {}
 /**
  * Creates an ECharts instance, and returns an echartsInstance. You shall
  *      not initialize multiple ECharts instances on a single container.

--- a/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
@@ -14,7 +14,7 @@ declare class Component mixins React.Component<Props> {
 `;
 
 exports[`should handle react types 1`] = `
-"import { Node } from \\"react\\";
+"import type { Node } from \\"react\\";
 import * as React from \\"react\\";
 declare function s(node: Node): void;
 declare function s(node: React.Node): void;

--- a/src/__tests__/__snapshots__/string-literals.spec.ts.snap
+++ b/src/__tests__/__snapshots__/string-literals.spec.ts.snap
@@ -8,8 +8,8 @@ declare export var SET_STAGE: any; // \\"my/lib/SET_STAGE\\"
 
 exports[`should handle string literals in function argument "overloading" 1`] = `
 "declare interface MyObj {
-  on(event: \\"error\\", cb: (err: Error) => void): this;
-  on(event: \\"close\\", cb: (code: number, message: string) => void): this;
+  on(event: \\"error\\", cb: (err: Error) => void): void;
+  on(event: \\"close\\", cb: (code: number, message: string) => void): void;
   on(
     event: \\"message\\",
     cb: (
@@ -19,7 +19,7 @@ exports[`should handle string literals in function argument "overloading" 1`] = 
         ...
       }
     ) => void
-  ): this;
+  ): void;
   on(
     event: \\"ping\\",
     cb: (
@@ -29,7 +29,7 @@ exports[`should handle string literals in function argument "overloading" 1`] = 
         ...
       }
     ) => void
-  ): this;
+  ): void;
   on(
     event: \\"pong\\",
     cb: (
@@ -39,9 +39,9 @@ exports[`should handle string literals in function argument "overloading" 1`] = 
         ...
       }
     ) => void
-  ): this;
-  on(event: \\"open\\", cb: () => void): this;
-  on(event: string, listener: (...args: any[]) => void): this;
+  ): void;
+  on(event: \\"open\\", cb: () => void): void;
+  on(event: string, listener: (...args: any[]) => void): void;
 }
 "
 `;

--- a/src/__tests__/__snapshots__/variables.spec.ts.snap
+++ b/src/__tests__/__snapshots__/variables.spec.ts.snap
@@ -11,7 +11,7 @@ declare var baz: number;
 declare var quuz: any;
 declare var quuuz: string;
 declare var quuuuz: number;
-declare var quuuuz: string;
+declare var quuuuuz: string;
 declare var fox: number;
 "
 `;

--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle basic keywords", () => {
   const ts = `type A = {
@@ -27,4 +28,5 @@ it("should handle basic keywords", () => {
   }`;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/boolean-literals.spec.ts
+++ b/src/__tests__/boolean-literals.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle boolean literals in type", () => {
   const ts = `
@@ -9,4 +10,5 @@ it("should handle boolean literals in type", () => {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/classes.spec.ts
+++ b/src/__tests__/classes.spec.ts
@@ -1,7 +1,11 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle static methods ES6 classes", () => {
-  const ts = `class Observable<T> implements Subscribable<T> {
+  const ts = `
+  class Subscribable<T> {}
+  class Operator<T, R> {}
+  class Observable<T> implements Subscribable<T> {
     create: Function;
     static create: Function;
     lift<R>(operator: Operator<T, R>): Observable<R>;
@@ -18,7 +22,9 @@ it("should handle static methods ES6 classes", () => {
     protected get cfnProperties(): {
       [key: string]: any;
     };
-  }`;
+  }
+  `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/computed.spec.ts
+++ b/src/__tests__/computed.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle computed Symbol.iterator and Symbol.asyncIterator", () => {
   const ts = `
@@ -61,6 +62,7 @@ it("should handle computed Symbol.iterator and Symbol.asyncIterator", () => {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle string literals", () => {
@@ -100,6 +102,7 @@ it("should handle string literals", () => {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should approximate unsupported keys", () => {
@@ -139,4 +142,5 @@ it("should approximate unsupported keys", () => {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // unsupported-syntax
 });

--- a/src/__tests__/enums.spec.ts
+++ b/src/__tests__/enums.spec.ts
@@ -1,9 +1,11 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle empty enums", () => {
   const ts = `enum Empty { }`;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot("class");
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle basic enums", () => {
@@ -17,6 +19,7 @@ type B = Label.LABEL_OPTIONAL
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot("class");
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle number enums", () => {
@@ -32,6 +35,7 @@ type B = Label.TWO
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot("class");
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle string enums", () => {
@@ -45,4 +49,5 @@ type B = Label.LABEL_REQUIRED
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot("class");
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/exports.spec.ts
+++ b/src/__tests__/exports.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle exports", () => {
   const ts = `
@@ -14,6 +15,7 @@ export * from 'typescript';
 //export * as t from "@babel/types";`;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-module
 });
 
 test("should handle unnamed default export", () => {
@@ -22,4 +24,5 @@ export default function(): void;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/function-exports.spec.ts
+++ b/src/__tests__/function-exports.spec.ts
@@ -1,11 +1,20 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle exported es module functions", () => {
-  const ts = `export function routerReducer(state?: RouterState, action?: Action): RouterState;
+  const ts = `
+class Action {}
+class RouterState {}
+class Store<T> {}
+class SyncHistoryWithStoreOptions {}
+class HistoryUnsubscribe {}
+
+export function routerReducer(state?: RouterState, action?: Action): RouterState;
 export function syncHistoryWithStore(history: History, store: Store<any>, options?: SyncHistoryWithStoreOptions): History & HistoryUnsubscribe;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle toString function overload", () => {
@@ -15,20 +24,31 @@ export function toString(b: string): void;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle default exported es module functions", () => {
-  const ts = `export default function routerReducer(state?: RouterState, action?: Action): RouterState;`;
+  const ts = `
+class Action {}
+class RouterState {}
+
+export default function routerReducer(state?: RouterState, action?: Action): RouterState;`;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle function overload es module functions", () => {
-  const ts = `export function routerReducer(state?: RouterState, action?: Action): RouterState;
+  const ts = `
+class Action {}
+class RouterState {}
+
+export function routerReducer(state?: RouterState, action?: Action): RouterState;
 export function routerReducer(state?: RouterState): RouterState;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should remove this annotation from functions", () => {
@@ -36,6 +56,7 @@ it("should remove this annotation from functions", () => {
     "function addClickListener(onclick: (this: void, e: Event) => void): void;";
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should remove default parameters from functions", () => {
@@ -43,4 +64,5 @@ it("should remove default parameters from functions", () => {
     "function addClickListener<T = Error>(onclick: (e: Event) => void): T;";
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/global-declares.spec.ts
+++ b/src/__tests__/global-declares.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle declared interfaces", () => {
   const ts = `
@@ -7,7 +8,7 @@ declare interface ICustomMessage {
   otherMethod(literal: "A"|"B"): void;
 }
 `;
-  expect(
-    beautify(compiler.compileDefinitionString(ts, { quiet: true })),
-  ).toMatchSnapshot();
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/global-this.spec.ts
+++ b/src/__tests__/global-this.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should not crash when getting globalThis in code", () => {
   const ts = `import * as React from 'react';
@@ -11,4 +12,5 @@ export default class MenuStatefulContainer extends React.Component {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // missing-type-arg,prop-missing
 });

--- a/src/__tests__/import.spec.ts
+++ b/src/__tests__/import.spec.ts
@@ -1,11 +1,12 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle dynamic imports", () => {
   const ts = `
 type A = import('react');
 type B = import('react').ReactNode;
 `;
-  expect(
-    beautify(compiler.compileDefinitionString(ts, { quiet: true })),
-  ).toMatchSnapshot();
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/imports.spec.ts
+++ b/src/__tests__/imports.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle imports", () => {
   const ts = `import { GeneratorOptions } from "@babel/generator";
@@ -9,6 +10,7 @@ import * as t from "@babel/types";
 import v, * as d from 'typescript';`;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-module
 });
 
 it("should handle imports inside module", () => {
@@ -24,6 +26,7 @@ declare module '@babel/core' {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-module
 });
 
 it("should handle import type", () => {
@@ -32,6 +35,7 @@ type S = typeof import('http')
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle type imports", () => {
@@ -41,4 +45,5 @@ import type { Visitor as NewVisitor } from "@babel/traverse";
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-module
 });

--- a/src/__tests__/interface-exports.spec.ts
+++ b/src/__tests__/interface-exports.spec.ts
@@ -1,11 +1,12 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle exported interfaces", () => {
   const ts = `export interface UnaryFunction<T, R> {
     (source: T): R;
   }
 `;
-  expect(
-    beautify(compiler.compileDefinitionString(ts, { quiet: true })),
-  ).toMatchSnapshot();
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/interfaces.spec.ts
+++ b/src/__tests__/interfaces.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle single interface", () => {
   const ts = `
@@ -8,10 +9,12 @@ interface User {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
   const result2 = compiler.compileDefinitionString(ts, {
     interfaceRecords: true,
   });
   expect(beautify(result2)).toMatchSnapshot();
+  expect(result2).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle interface inheritance", () => {
@@ -25,10 +28,12 @@ interface SpecialUser extends User {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
   const result2 = compiler.compileDefinitionString(ts, {
     interfaceRecords: true,
   });
   expect(beautify(result2)).toMatchSnapshot();
+  expect(result2).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle interface merging", () => {
@@ -45,10 +50,12 @@ interface User {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
   const result2 = compiler.compileDefinitionString(ts, {
     interfaceRecords: true,
   });
   expect(beautify(result2)).toMatchSnapshot();
+  expect(result2).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle all properties", () => {
@@ -62,6 +69,7 @@ interface Props {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // unsupported-syntax
 });
 
 it("should support readonly modifier", () => {
@@ -73,10 +81,13 @@ interface Helper {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should support call signature", () => {
   const ts = `
+  interface ObjectSchema<T> {}
+  interface ObjectSchemaDefinition<T> {}
   declare interface ObjectSchemaConstructor {
     <T extends object>(fields?: ObjectSchemaDefinition<T>): ObjectSchema<T>;
     new (): ObjectSchema<{}>;
@@ -84,6 +95,7 @@ it("should support call signature", () => {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should remove this in call signature", () => {
@@ -102,16 +114,19 @@ interface C<This, Datum> {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should remove generic defaults in call signature", () => {
   const ts = `
+interface AbstractLevelDOWN<K, V> {}
 interface AbstractLevelDOWNConstructor {
     <K = any, V = any>(location: string): AbstractLevelDOWN<K, V>;
 }  
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should support omitting generic defaults in types, classes, interfaces", () => {
@@ -131,6 +146,7 @@ declare var f: Baz<any>
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should support optional methods", () => {
@@ -142,6 +158,7 @@ interface Example<State> {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle toString property name", () => {
@@ -152,6 +169,7 @@ interface A {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle untyped object binding pattern", () => {
@@ -164,6 +182,7 @@ interface ObjectBinding {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle untyped array binding pattern", () => {
@@ -176,6 +195,7 @@ interface ArrayBinding {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle typed object binding pattern", () => {
@@ -188,6 +208,7 @@ interface ObjectBinding {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle typed array binding pattern", () => {
@@ -200,4 +221,5 @@ interface ArrayBinding {
 `;
   const result = compiler.compileDefinitionString(ts);
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/jsdoc.spec.ts
+++ b/src/__tests__/jsdoc.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle basic jsdoc", () => {
   const ts = `const skip: number
@@ -48,6 +49,8 @@ declare var patchOuter: <T>(
   data?: T,
 ) => Node | null;
 
+declare class ECharts {}
+
 /**
  * Creates an ECharts instance, and returns an echartsInstance. You shall
  *     not initialize multiple ECharts instances on a single container.
@@ -88,6 +91,7 @@ declare function test(): Promise<void>
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should remove jsdoc", () => {
@@ -103,4 +107,5 @@ declare function authorize(userToken: string): Promise<void>
     jsdoc: false,
   });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/mapped-types.spec.ts
+++ b/src/__tests__/mapped-types.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle mapped types", () => {
   const ts = `
@@ -18,4 +19,5 @@ type ConstantKey = MappedObj["a"]
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/module-identifiers.spec.ts
+++ b/src/__tests__/module-identifiers.spec.ts
@@ -1,14 +1,16 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle react types", () => {
   const ts = `
-import {ReactNode} from 'react'
+import type {ReactNode} from 'react'
 import * as React from 'react'
 declare function s(node: ReactNode): void;
 declare function s(node: React.ReactNode): void;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 describe("should handle global types", () => {
@@ -25,5 +27,6 @@ declare class Component extends React.Component<Props> {
 `;
     const result = compiler.compileDefinitionString(ts, { quiet: true });
     expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
   });
 });

--- a/src/__tests__/modules.spec.ts
+++ b/src/__tests__/modules.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle module", () => {
   const ts = `
@@ -13,6 +14,7 @@ declare module 'test' {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle module merging", () => {
@@ -32,6 +34,7 @@ declare module 'test' {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should not merge distinct modules", () => {
@@ -52,6 +55,7 @@ export interface A {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle module function merging", () => {
@@ -65,4 +69,5 @@ declare module 'test' {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/namespaces.spec.ts
+++ b/src/__tests__/namespaces.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 describe("should handle merging with other types", () => {
   describe("function", () => {
@@ -13,6 +14,7 @@ namespace test {
 `;
       const result = compiler.compileDefinitionString(ts);
       expect(beautify(result)).toMatchSnapshot();
+      expect(result).toBeValidFlowTypeDeclarations();
     });
 
     test("type", () => {
@@ -26,6 +28,7 @@ namespace test {
 `;
       const result = compiler.compileDefinitionString(ts);
       expect(beautify(result)).toMatchSnapshot();
+      expect(result).toBeValidFlowTypeDeclarations();
     });
 
     test("const", () => {
@@ -37,6 +40,7 @@ namespace test {
 `;
       const result = compiler.compileDefinitionString(ts);
       expect(beautify(result)).toMatchSnapshot();
+      expect(result).toBeValidFlowTypeDeclarations();
     });
   });
 
@@ -52,6 +56,7 @@ namespace Album {
 `;
     const result = compiler.compileDefinitionString(ts);
     expect(beautify(result)).toMatchSnapshot();
+    expect(result).not.toBeValidFlowTypeDeclarations(); // TODO: prop-missing
   });
 
   test("enum", () => {
@@ -68,6 +73,7 @@ namespace Color {
 `;
     const result = compiler.compileDefinitionString(ts);
     expect(beautify(result)).toMatchSnapshot();
+    expect(result).not.toBeValidFlowTypeDeclarations(); // TODO: prop-missing
   });
 });
 
@@ -79,6 +85,7 @@ namespace test {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle namespace merging", () => {
@@ -92,6 +99,7 @@ namespace test {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle namespace function merging", () => {
@@ -105,6 +113,7 @@ namespace test {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle exported interfaces and types", () => {
@@ -115,6 +124,7 @@ namespace Example {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle nested namespaces", () => {
@@ -161,6 +171,7 @@ declare namespace E0 {
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-module
 });
 
 test("should handle qualified namespaces", () => {
@@ -169,7 +180,7 @@ declare namespace A.B {
   interface S<A> {
     readonly d: A;
     b: number;
-  }
+}
   declare class D<S> {}
 }
 
@@ -180,6 +191,7 @@ declare namespace A.B.C {
 }`;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // TODO: type-as-value
 });
 
 test("should handle global augmentation", () => {
@@ -189,6 +201,7 @@ declare global {
 }`;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 test("should handle import equals declaration", () => {
@@ -197,4 +210,5 @@ import hello = A.B;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-name
 });

--- a/src/__tests__/string-literals.spec.ts
+++ b/src/__tests__/string-literals.spec.ts
@@ -1,21 +1,23 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it('should handle string literals in function argument "overloading"', () => {
   const ts = `
   interface MyObj {
-      on(event: 'error', cb: (err: Error) => void): this;
-      on(event: 'close', cb: (code: number, message: string) => void): this;
-      on(event: 'message', cb: (data: any, flags: { binary: boolean }) => void): this;
-      on(event: 'ping', cb: (data: any, flags: { binary: boolean }) => void): this;
-      on(event: 'pong', cb: (data: any, flags: { binary: boolean }) => void): this;
-      on(event: 'open', cb: () => void): this;
-      on(event: string, listener: (...args: any[]) => void): this;
+      on(event: 'error', cb: (err: Error) => void): void;
+      on(event: 'close', cb: (code: number, message: string) => void): void;
+      on(event: 'message', cb: (data: any, flags: { binary: boolean }) => void): void;
+      on(event: 'ping', cb: (data: any, flags: { binary: boolean }) => void): void;
+      on(event: 'pong', cb: (data: any, flags: { binary: boolean }) => void): void;
+      on(event: 'open', cb: () => void): void;
+      on(event: string, listener: (...args: any[]) => void): void;
   }
 `;
 
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle exported constant string literals", () => {
@@ -27,4 +29,5 @@ it("should handle exported constant string literals", () => {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/tuples.spec.ts
+++ b/src/__tests__/tuples.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle tuples", () => {
   const ts = `
@@ -7,4 +8,5 @@ it("should handle tuples", () => {
   `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/type-exports.spec.ts
+++ b/src/__tests__/type-exports.spec.ts
@@ -1,11 +1,12 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle exported types", () => {
   const ts = `
 export declare type FactoryOrValue<T> = T | (() => T);
 export type Maybe<T> = {type: 'just', value: T} | {type: 'nothing'}
 `;
-  expect(
-    beautify(compiler.compileDefinitionString(ts, { quiet: true })),
-  ).toMatchSnapshot();
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/union-strings.spec.ts
+++ b/src/__tests__/union-strings.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle union strings", () => {
   const ts = `
@@ -11,4 +12,5 @@ it("should handle union strings", () => {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/utility-types.spec.ts
+++ b/src/__tests__/utility-types.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle utility types", () => {
   const ts = `
@@ -27,4 +28,5 @@ type F2<T, U> = Record<T, U>
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/value-exports.spec.ts
+++ b/src/__tests__/value-exports.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle exported es module values", () => {
   const ts = `declare var test: {a: number};
@@ -6,6 +7,7 @@ export {test};
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle default exported es module values", () => {
@@ -14,4 +16,5 @@ export default test;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/__tests__/variables.spec.ts
+++ b/src/__tests__/variables.spec.ts
@@ -1,4 +1,5 @@
 import { compiler, beautify } from "..";
+import "../test-matchers";
 
 it("should handle declares", () => {
   const ts = `
@@ -9,8 +10,9 @@ declare var baz: number;
 declare var quuz: any, quuuz: string;
 
 declare let quuuuz: number;
-declare let quuuuz: string, fox: number;
+declare let quuuuuz: string, fox: number;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/cli/__tests__/compiler.spec.ts
+++ b/src/cli/__tests__/compiler.spec.ts
@@ -1,5 +1,6 @@
 import compiler from "../compiler";
 import beautify from "../beautifier";
+import "../../test-matchers";
 
 it("should handle maybe & nullable type", () => {
   const result = compiler.compileDefinitionString(
@@ -8,6 +9,7 @@ it("should handle maybe & nullable type", () => {
   );
 
   expect(result).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle bounded polymorphism", () => {
@@ -21,4 +23,5 @@ it("should handle bounded polymorphism", () => {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });

--- a/src/cli/__tests__/fixtures.spec.ts
+++ b/src/cli/__tests__/fixtures.spec.ts
@@ -1,5 +1,6 @@
 import compiler from "../compiler";
 import beautify from "../beautifier";
+import "../../test-matchers";
 import fs from "fs";
 
 it("handles the danger.d.ts correctly", () => {
@@ -10,4 +11,5 @@ it("handles the danger.d.ts correctly", () => {
   const result = compiler.compileDefinitionString(dangerDTS, { quiet: true });
 
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-module
 });

--- a/src/test-matchers.ts
+++ b/src/test-matchers.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from "child_process";
+
+import chalk from "chalk";
+import flow from "flow-bin";
+
+import { beautify } from ".";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
+    interface Matchers<R> {
+      toBeValidFlowTypeDeclarations(): R;
+    }
+  }
+}
+
+expect.extend({
+  toBeValidFlowTypeDeclarations(source) {
+    const beautifiedSource = beautify(source);
+    try {
+      execFileSync(
+        flow,
+        ["check-contents", "--all", "--color=always", "--timeout=30"],
+        {
+          input: beautifiedSource,
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+    } catch (err) {
+      return {
+        message: () =>
+          `expected ${chalk.bold(
+            beautifiedSource.trimEnd(),
+          )} to be valid flow:\n${chalk.red(err.stdout)}`,
+        pass: false,
+      };
+    }
+
+    return {
+      message: () =>
+        `expected ${chalk.bold(
+          beautifiedSource.trimEnd(),
+        )} not to be valid flow`,
+      pass: true,
+    };
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,7 +1809,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -2618,6 +2618,11 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+flow-bin@^0.141.0:
+  version "0.141.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.141.0.tgz#f9e33ad29392824823c97b6db7de5ab972c7f872"
+  integrity sha512-NxaECTjIWfs2Y91GuA1PlgPd5uCulZcqR9wiXRg6n7/AbmvVetM2ewoGxCKxJm7wIml3f0/5KXIZvZa/3msqXg==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This change makes all* tests run `flow check-contents` on the generated
flow declarations. This ensures that the generated code is valid.

\* most. Some tests produce invalid output due to bugs, some cannot be
verified due to missing imports.