### PR TITLE
no-inexact: make type declarations exact as well

### DIFF
--- a/src/__tests__/__snapshots__/basic.spec.ts.snap
+++ b/src/__tests__/__snapshots__/basic.spec.ts.snap
@@ -28,3 +28,31 @@ exports[`should handle basic keywords 1`] = `
 };
 "
 `;
+
+exports[`should handle basic keywords 2`] = `
+"declare type A = {|
+  a: void,
+  b: string,
+  c: any,
+  d: number,
+  e: boolean,
+  f: null,
+  g: void,
+  h: { [key: string]: any },
+  i: 1,
+  j: 2,
+  k: true,
+  l: false,
+  m: \\"foo\\",
+  n: \\"bar\\",
+  o: empty,
+  p: mixed,
+  r: -1,
+  s: -2,
+  t: Symbol,
+  u: Symbol,
+  v: [1, 2, 3],
+  w: $ReadOnlyArray<string>,
+|};
+"
+`;

--- a/src/__tests__/__snapshots__/basic.spec.ts.snap
+++ b/src/__tests__/__snapshots__/basic.spec.ts.snap
@@ -56,3 +56,13 @@ exports[`should handle basic keywords 2`] = `
 |};
 "
 `;
+
+exports[`should handle class types 1`] = `
+"declare export class Foo {}
+"
+`;
+
+exports[`should handle class types 2`] = `
+"declare export class Foo {}
+"
+`;

--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -42,3 +42,25 @@ it("should handle basic keywords", () => {
     expect(result).toBeValidFlowTypeDeclarations();
   }
 });
+
+it("should handle class types", () => {
+  const ts = `
+  declare export class Foo {
+  }`;
+
+  {
+    const result = compiler.compileDefinitionString(ts, { quiet: true });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+
+  {
+    const result = compiler.compileDefinitionString(ts, {
+      quiet: true,
+      inexact: false,
+    });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+});
+

--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -26,7 +26,19 @@ it("should handle basic keywords", () => {
     v: readonly [1, 2, 3],
     w: readonly string[],
   }`;
-  const result = compiler.compileDefinitionString(ts, { quiet: true });
-  expect(beautify(result)).toMatchSnapshot();
-  expect(result).toBeValidFlowTypeDeclarations();
+
+  {
+    const result = compiler.compileDefinitionString(ts, { quiet: true });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+
+  {
+    const result = compiler.compileDefinitionString(ts, {
+      quiet: true,
+      inexact: false,
+    });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
 });

--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -63,4 +63,3 @@ it("should handle class types", () => {
     expect(result).toBeValidFlowTypeDeclarations();
   }
 });
-

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -113,7 +113,7 @@ export const interfaceType = <T>(
     .filter(Boolean) // Filter rows which didn't print properly (private fields et al)
     .join(withSemicolons ? ";" : ",");
 
-  return isInexact
+  return isInexact || !ts.isTypeLiteralNode(node)
     ? `{${inner}}`
     : `{|${inner}|}`;
 };

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -109,9 +109,13 @@ export const interfaceType = <T>(
     members.push("\n");
   }
 
-  return `{${members
-    .filter(Boolean) // Filter rows which didnt print propely (private fields et al)
-    .join(withSemicolons ? ";" : ",")}}`;
+  const inner = members
+    .filter(Boolean) // Filter rows which didn't print properly (private fields et al)
+    .join(withSemicolons ? ";" : ",");
+
+  return isInexact
+    ? `{${inner}}`
+    : `{|${inner}|}`;
 };
 
 const interfaceRecordType = (

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -113,7 +113,11 @@ export const interfaceType = <T>(
     .filter(Boolean) // Filter rows which didn't print properly (private fields et al)
     .join(withSemicolons ? ";" : ",");
 
-  return isInexact || !ts.isTypeLiteralNode(node)
+  // we only want type literals to be exact. i.e. class Foo {} should not be class Foo {||}
+  if (!ts.isTypeLiteralNode(node)) {
+    return `{${inner}}`;
+  }
+  return isInexact
     ? `{${inner}}`
     : `{|${inner}|}`;
 };

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -117,9 +117,7 @@ export const interfaceType = <T>(
   if (!ts.isTypeLiteralNode(node)) {
     return `{${inner}}`;
   }
-  return isInexact
-    ? `{${inner}}`
-    : `{|${inner}|}`;
+  return isInexact ? `{${inner}}` : `{|${inner}|}`;
 };
 
 const interfaceRecordType = (


### PR DESCRIPTION
The `no-inexact` parameter is defined as "output without inexact types"

This flag gets rid of the `...` notation and replaces it with `{|  |}` for interface-based types, but for regular type definitions it seems to just get rid of the `...` without adding the exact-type notation (possibly this was an oversight)

### Before this PR

For the input
```typescript
type Foo = { a: string }
```

`no-inexact = false` gives
```typescript
type Foo = {
   a: string,
   ... 
}
```

`no-inexact = true` gives
```typescript
type Foo = {
    a: string
}
```

### After this PR

For the input
```typescript
type Foo = { a: string }
```

`no-inexact = false` gives
```typescript
type Foo = {
   a: string,
   ... 
}
```

`no-inexact = true` gives
```typescript
type Foo = {|
    a: string
|}
```