### PR TITLE
Add support for spread operator when intersecting types

### DIFF
--- a/src/__tests__/__snapshots__/spread.spec.ts.snap
+++ b/src/__tests__/__snapshots__/spread.spec.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not insert spread when performing union of class types 1`] = `
+"declare class Foo {}
+declare class Bar {}
+declare var combination: Foo & Bar;
+"
+`;
+
+exports[`should use spread when performing union of object types 1`] = `
+"declare type Foo = {
+  foo: number,
+  ...
+};
+declare type Bar = {
+  bar: string,
+  ...
+};
+declare var combination: { ...Foo, ...Bar };
+"
+`;
+
+exports[`should use spread when performing union of object types 2`] = `
+"declare type Foo = {|
+  foo: number,
+|};
+declare type Bar = {|
+  bar: string,
+|};
+declare var combination: {| ...Foo, ...Bar |};
+"
+`;

--- a/src/__tests__/spread.spec.ts
+++ b/src/__tests__/spread.spec.ts
@@ -1,0 +1,34 @@
+import { compiler, beautify } from "..";
+import "../test-matchers";
+
+it("should use spread when performing union of object types", () => {
+  const ts = `
+type Foo = { foo: number };
+type Bar = { bar: string };
+const combination: Foo & Bar;
+`;
+
+  {
+    const result = compiler.compileDefinitionString(ts, { quiet: true });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+
+  {
+    const result = compiler.compileDefinitionString(ts, { quiet: true, inexact: false });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+});
+
+
+it("should not insert spread when performing union of class types", () => {
+  const ts = `
+class Foo {}
+class Bar {}
+const combination: Foo & Bar;
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/__tests__/spread.spec.ts
+++ b/src/__tests__/spread.spec.ts
@@ -15,12 +15,14 @@ const combination: Foo & Bar;
   }
 
   {
-    const result = compiler.compileDefinitionString(ts, { quiet: true, inexact: false });
+    const result = compiler.compileDefinitionString(ts, {
+      quiet: true,
+      inexact: false,
+    });
     expect(beautify(result)).toMatchSnapshot();
     expect(result).toBeValidFlowTypeDeclarations();
   }
 });
-
 
 it("should not insert spread when performing union of class types", () => {
   const ts = `

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -749,7 +749,7 @@ export const printType = withEnv<any, [any], string>(
         }
         return "";
 
-      case ts.SyntaxKind.IntersectionType:
+      case ts.SyntaxKind.IntersectionType: {
         // for non-class types, we can't easily just merge types together using &
         // this is because in Typescript
         // { a: number } & { b: string}
@@ -766,13 +766,14 @@ export const printType = withEnv<any, [any], string>(
           return type.types.map(printType).join(" & ");
         }
 
-        const spreadType = type.types.map(type => `...${printType(type)}`).join(",");
+        const spreadType = type.types
+          .map(type => `...${printType(type)}`)
+          .join(",");
 
         const isInexact = opts().inexact;
 
-        return isInexact
-          ? `{ ${spreadType} }`
-          : `{| ${spreadType} |}`;
+        return isInexact ? `{ ${spreadType} }` : `{| ${spreadType} |}`;
+      }
 
       case ts.SyntaxKind.MethodDeclaration:
         // Skip methods marked as private


### PR DESCRIPTION
## ⚠️ Warning: This PR depends on https://github.com/joarwilk/flowgen/pull/135

The way intersection types work in Typescript and Flow is different. Notably, for the following Typescript

```typescript
{ a: number } & { b: string }
```

The correct Flow equivalent is NOT
```typescript
{| a: number |} & {| b: string |}
```

You have to instead use the spread operator (see https://github.com/facebook/flow/issues/4946#issuecomment-331520118 )

This PR adds a check to see whether or not we need to use the spread notation when converting to the Flow type.