### PR TITLE
Use literals as types instead of any

### DIFF
--- a/src/__tests__/__snapshots__/boolean-literals.spec.ts.snap
+++ b/src/__tests__/__snapshots__/boolean-literals.spec.ts.snap
@@ -3,6 +3,6 @@
 exports[`should handle boolean literals in type 1`] = `
 "declare type MyFalsyType = string | false;
 declare type MyTruthyType = true | string;
-declar var foo: true;
+declare var foo: true;
 "
 `;

--- a/src/__tests__/__snapshots__/boolean-literals.spec.ts.snap
+++ b/src/__tests__/__snapshots__/boolean-literals.spec.ts.snap
@@ -3,5 +3,6 @@
 exports[`should handle boolean literals in type 1`] = `
 "declare type MyFalsyType = string | false;
 declare type MyTruthyType = true | string;
+declar var foo: true;
 "
 `;

--- a/src/__tests__/__snapshots__/string-literals.spec.ts.snap
+++ b/src/__tests__/__snapshots__/string-literals.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle exported constant string literals 1`] = `
-"declare export var SET_NAME: any; // \\"my/lib/SET_NAME\\"
-declare export var SET_STAGE: any; // \\"my/lib/SET_STAGE\\"
+"declare export var SET_NAME: \\"my/lib/SET_NAME\\";
+declare export var SET_STAGE: \\"my/lib/SET_STAGE\\";
 "
 `;
 

--- a/src/__tests__/boolean-literals.spec.ts
+++ b/src/__tests__/boolean-literals.spec.ts
@@ -5,6 +5,7 @@ it("should handle boolean literals in type", () => {
   const ts = `
   type MyFalsyType = string | false;
   type MyTruthyType = true | string;
+  const foo = true;
 `;
 
   const result = compiler.compileDefinitionString(ts, { quiet: true });

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -57,7 +57,7 @@ export const propertyDeclaration = (
     return left + ": " + right;
   }
 
-  return left + `: any // ${printers.node.printType(node.initializer)}\n`;
+  return left + `: ${printers.node.printType(node.initializer)}\n`;
 };
 
 export const variableDeclaration = (node: RawNode): string => {


### PR DESCRIPTION
Flow allows setting literals as types, so I don't know what was the justification for setting them to `any` instead of just using the literal. 

This doesn't cause any issues with casting either since the following is entirely valid

```typescript
const foo: 5 = 5;
const bar: number = foo;
```