### PR TITLE
bugfix: export list of types

### DIFF
--- a/src/__tests__/__snapshots__/type-exports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/type-exports.spec.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should handle export list syntax 1`] = `
+"declare type ComplexType =
+  | {
+      type: number,
+      ...
+    }
+  | {
+      type: string,
+      ...
+    };
+export type { ComplexType };
+declare var foo: 5;
+declare export { foo };
+"
+`;
+
 exports[`should handle exported types 1`] = `
 "export type FactoryOrValue<T> = T | (() => T);
 export type Maybe<T> =

--- a/src/__tests__/type-exports.spec.ts
+++ b/src/__tests__/type-exports.spec.ts
@@ -10,3 +10,19 @@ export type Maybe<T> = {type: 'just', value: T} | {type: 'nothing'}
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle export list syntax", () => {
+  const ts = `
+declare type ComplexType = {
+    type: number
+} | {
+    type: string
+};
+export type { ComplexType };
+const foo = 5;
+export { foo };
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/nodes/export-declaration.ts
+++ b/src/nodes/export-declaration.ts
@@ -1,7 +1,9 @@
 import type { RawNode } from "./node";
+import * as ts from "typescript";
 import type { Expression, ExportDeclaration as RawExport } from "typescript";
 import * as printers from "../printers";
 import Node from "./node";
+import { checker } from "../checker";
 
 type ExportDeclarationType = RawExport & {
   moduleSpecifier?: Expression & {
@@ -19,12 +21,27 @@ export default class ExportDeclaration extends Node<ExportDeclarationType> {
     if (this.raw.exportClause) {
       // @ts-expect-error todo(flow->ts)
       const elements = this.raw.exportClause.elements;
+
       let specifier = "";
       if (this.raw.moduleSpecifier)
         specifier = `from '${this.raw.moduleSpecifier.text}';`;
-      return `declare export {
-        ${elements.map(node => printers.node.printType(node))}
-      }${specifier}\n`;
+
+      const typeExports = elements.filter(ts.isTypeOnlyImportOrExportDeclaration);
+      const varExports = elements.filter(node => !ts.isTypeOnlyImportOrExportDeclaration(node));
+
+      let result = "";
+      if (typeExports.length > 0) {
+        result += `export type {
+          ${elements.map(node => printers.node.printType(node))}
+        }${specifier}\n`;
+      }
+      if (varExports.length > 0) {
+        result += `declare export {
+          ${elements.map(node => printers.node.printType(node))}
+        }${specifier}\n`;
+      }
+
+      return result;
     } else {
       return `declare export * from '${this.raw.moduleSpecifier.text}';\n`;
     }

--- a/src/nodes/export-declaration.ts
+++ b/src/nodes/export-declaration.ts
@@ -21,27 +21,21 @@ export default class ExportDeclaration extends Node<ExportDeclarationType> {
     if (this.raw.exportClause) {
       // @ts-expect-error todo(flow->ts)
       const elements = this.raw.exportClause.elements;
+      const isTypeImport = this.raw.isTypeOnly;
 
       let specifier = "";
       if (this.raw.moduleSpecifier)
         specifier = `from '${this.raw.moduleSpecifier.text}';`;
 
-      const typeExports = elements.filter(ts.isTypeOnlyImportOrExportDeclaration);
-      const varExports = elements.filter(node => !ts.isTypeOnlyImportOrExportDeclaration(node));
-
-      let result = "";
-      if (typeExports.length > 0) {
-        result += `export type {
-          ${elements.map(node => printers.node.printType(node))}
-        }${specifier}\n`;
-      }
-      if (varExports.length > 0) {
-        result += `declare export {
+      const generateOutput = (prefix) => {
+        return `${prefix} {
           ${elements.map(node => printers.node.printType(node))}
         }${specifier}\n`;
       }
 
-      return result;
+      return isTypeImport
+        ? generateOutput(`export type`)
+        : generateOutput(`declare export`);
     } else {
       return `declare export * from '${this.raw.moduleSpecifier.text}';\n`;
     }

--- a/src/nodes/export-declaration.ts
+++ b/src/nodes/export-declaration.ts
@@ -1,9 +1,7 @@
 import type { RawNode } from "./node";
-import * as ts from "typescript";
 import type { Expression, ExportDeclaration as RawExport } from "typescript";
 import * as printers from "../printers";
 import Node from "./node";
-import { checker } from "../checker";
 
 type ExportDeclarationType = RawExport & {
   moduleSpecifier?: Expression & {
@@ -27,11 +25,11 @@ export default class ExportDeclaration extends Node<ExportDeclarationType> {
       if (this.raw.moduleSpecifier)
         specifier = `from '${this.raw.moduleSpecifier.text}';`;
 
-      const generateOutput = (prefix) => {
+      const generateOutput = prefix => {
         return `${prefix} {
           ${elements.map(node => printers.node.printType(node))}
         }${specifier}\n`;
-      }
+      };
 
       return isTypeImport
         ? generateOutput(`export type`)


### PR DESCRIPTION
When trying to export a list of types, the code would accidentally use `declare export` instead of `export type`. This PR fixes this issue.