### PR TITLE
bugfix: fix import type for enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run compile",
-    "compile": "babel ./src --extensions '.ts,.tsx,.js' --out-dir lib --delete-dir-on-start --ignore 'src/**/*.spec.ts'",
+    "compile": "babel ./src --extensions '.ts,.tsx,.js' --out-dir lib --delete-dir-on-start --ignore 'src/**/*.spec.ts' --ignore 'src/__tests__/'",
     "compile:watch": "npm run compile -- -w",
     "test": "jest src/**/*.spec.ts",
     "test:watch": "jest src/**/*.spec.ts --watch",

--- a/src/__tests__/__snapshots__/enums.spec.ts.snap
+++ b/src/__tests__/__snapshots__/enums.spec.ts.snap
@@ -16,6 +16,34 @@ exports[`should handle empty enums: class 1`] = `
 "
 `;
 
+exports[`should handle importing enum types: class 1`] = `
+"declare export var Label: {|
+  +A: \\"A\\", // \\"A\\"
+  +B: \\"B\\", // \\"B\\"
+|};
+"
+`;
+
+exports[`should handle importing enum types: class 2`] = `
+"import typeof { Label } from \\"./export-enum-file\\";
+declare export function foo(label: $Values<Label>): void;
+"
+`;
+
+exports[`should handle importing enums: class 1`] = `
+"declare export var Label: {|
+  +A: \\"A\\", // \\"A\\"
+  +B: \\"B\\", // \\"B\\"
+|};
+"
+`;
+
+exports[`should handle importing enums: class 2`] = `
+"import { Label } from \\"./export-enum-file\\";
+declare export function foo(label: $Values<typeof Label>): void;
+"
+`;
+
 exports[`should handle number enums: class 1`] = `
 "declare var Label: {|
   +ONE: 1, // 1

--- a/src/__tests__/enums.spec.ts
+++ b/src/__tests__/enums.spec.ts
@@ -51,3 +51,37 @@ type B = Label.LABEL_REQUIRED
   expect(beautify(result)).toMatchSnapshot("class");
   expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle importing enum types", () => {
+  const results = compiler.compileDefinitionFiles(
+    [
+      "src/__tests__/snippet/export-enum-file.ts",
+      "src/__tests__/snippet/import-enum-type-file.ts",
+    ],
+    {
+      quiet: false,
+    },
+  );
+  for (const result of results) {
+    expect(beautify(result[1])).toMatchSnapshot("class");
+    // TODO: this function only runs flow on one file at a time, so it errors when trying to import
+    // expect(result[1]).toBeValidFlowTypeDeclarations();
+  }
+});
+
+it("should handle importing enums", () => {
+  const results = compiler.compileDefinitionFiles(
+    [
+      "src/__tests__/snippet/export-enum-file.ts",
+      "src/__tests__/snippet/import-enum-file.ts",
+    ],
+    {
+      quiet: false,
+    },
+  );
+  for (const result of results) {
+    expect(beautify(result[1])).toMatchSnapshot("class");
+    // TODO: this function only runs flow on one file at a time, so it errors when trying to import
+    // expect(result[1]).toBeValidFlowTypeDeclarations();
+  }
+});

--- a/src/__tests__/snippet/export-enum-file.ts
+++ b/src/__tests__/snippet/export-enum-file.ts
@@ -1,0 +1,4 @@
+export enum Label {
+  A = "A",
+  B = "B",
+}

--- a/src/__tests__/snippet/import-enum-file.ts
+++ b/src/__tests__/snippet/import-enum-file.ts
@@ -1,0 +1,4 @@
+import { Label } from "./export-enum-file";
+export function foo(label: Label): void {
+  console.log(label);
+}

--- a/src/__tests__/snippet/import-enum-type-file.ts
+++ b/src/__tests__/snippet/import-enum-type-file.ts
@@ -1,0 +1,4 @@
+import type { Label } from "./export-enum-file";
+export function foo(label: Label): void {
+  console.log(label);
+}

--- a/src/nodes/import.ts
+++ b/src/nodes/import.ts
@@ -1,6 +1,8 @@
 import type { RawNode } from "./node";
 import Node from "./node";
 import * as printers from "../printers";
+import { checker } from "../checker";
+import * as ts from "typescript";
 
 export default class Import extends Node {
   constructor(node: RawNode) {
@@ -13,14 +15,54 @@ export default class Import extends Node {
       const bindings = this.raw.importClause.namedBindings;
       const name = this.raw.importClause.name;
       const isTypeImport = this.raw.importClause.isTypeOnly;
+
+      // in Typescript, you can use "import type" on an enum
+      // however, flowgen converts typescript enums to regular objects
+      // so that means "import type" would fail on them (can't import type a regular object)
+      // instead, we mimic this by using the import { typeof } notation
+      const splitTypeImports = elements => {
+        const enumElems = [];
+        const regularElems = [];
+        for (const elem of elements) {
+          // if we're not using import type, no need to do anything special
+          if (!isTypeImport) {
+            regularElems.push(elem);
+            continue;
+          }
+          const elemSymbol = checker.current.getTypeAtLocation(elem).symbol;
+          const isEnum =
+            elemSymbol &&
+            elemSymbol.declarations &&
+            elemSymbol.declarations[0].kind === ts.SyntaxKind.EnumDeclaration;
+          if (isEnum) {
+            enumElems.push(elem);
+          } else {
+            regularElems.push(elem);
+          }
+        }
+        return { enumElems, regularElems };
+      };
+
       if (name && bindings) {
         const elements = bindings.elements;
         if (elements) {
-          return `import${
-            this.module === "root" && !isTypeImport ? "" : " type"
-          } ${name.text}, {
-          ${elements.map(node => printers.node.printType(node))}
-        } from '${this.raw.moduleSpecifier.text}';\n`;
+          const { enumElems, regularElems } = splitTypeImports(elements);
+
+          let result = "";
+          if (regularElems.length > 0) {
+            result += `import${
+              this.module === "root" && !isTypeImport ? "" : " type"
+            } ${name.text}, {
+            ${elements.map(node => printers.node.printType(node))}
+            } from '${this.raw.moduleSpecifier.text}';\n`;
+          }
+          if (enumElems.length > 0) {
+            result += `import typeof ${name.text}, {
+              ${elements.map(node => printers.node.printType(node))}
+            } from '${this.raw.moduleSpecifier.text}';\n`;
+          }
+
+          return result;
         } else {
           const namespace = bindings.name.text;
           return `import${this.module === "root" ? "" : " typeof"} ${
@@ -36,11 +78,22 @@ export default class Import extends Node {
       if (bindings) {
         const elements = bindings.elements;
         if (elements) {
-          return `import${
-            this.module === "root" && !isTypeImport ? "" : " type"
-          } {
-          ${elements.map(node => printers.node.printType(node))}
-        } from '${this.raw.moduleSpecifier.text}';\n`;
+          const { enumElems, regularElems } = splitTypeImports(elements);
+
+          let result = "";
+          if (regularElems.length > 0) {
+            result += `import${
+              this.module === "root" && !isTypeImport ? "" : " type"
+            } {
+            ${regularElems.map(node => printers.node.printType(node))}
+            } from '${this.raw.moduleSpecifier.text}';\n`;
+          }
+          if (enumElems.length > 0) {
+            result += `import typeof {
+              ${enumElems.map(node => printers.node.printType(node))}
+            } from '${this.raw.moduleSpecifier.text}';\n`;
+          }
+          return result;
         } else {
           const name = bindings.name.text;
           return `import${


### PR DESCRIPTION
Background:

1) Typescript `enum` is converted to a regular object type by flowgen
2) Typescript allows you to do `import type` on an enum type. However, Flow doesn't allow you to `import type` on a regular object type
3) To allow enum values as a function parameter in Flow, you need to accept `$Values<...>` as the argument

Bug:
1) Using `import type` on an enum generated invalid Flow that tried to import an object as a type.
2) Code using enums as types was using the generated object directly as the type, but it needs to use the `$Values<...>` Flow notation 

Fix:
1) The new code now uses `import typeof` which is valid Flow notation
2) `$Values` is properly used for enums