### PR TITLE
Improve flowgen

### DIFF
--- a/src/__tests__/__snapshots__/interface-exports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/interface-exports.spec.ts.snap
@@ -6,3 +6,12 @@ exports[`should handle exported interfaces 1`] = `
 }
 "
 `;
+
+exports[`should handle exported interfaces within a module 1`] = `
+"declare module \\"my-module\\" {
+  declare export interface UnaryFunction<T, R> {
+    (source: T): R;
+  }
+}
+"
+`;

--- a/src/__tests__/__snapshots__/interfaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.ts.snap
@@ -63,6 +63,21 @@ exports[`should handle interface merging 2`] = `
 "
 `;
 
+exports[`should handle mutli-extends pattern 1`] = `
+"declare interface Shape {
+  color: string;
+}
+declare interface PenStroke {
+  penWidth: number;
+}
+declare type Square = {
+  sideLength: number,
+  ...
+} & Shape &
+  PenStroke;
+"
+`;
+
 exports[`should handle single interface 1`] = `
 "declare interface User {
   firstName: string;

--- a/src/__tests__/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.ts.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should handle Omit type 1`] = `
+"declare type A = $Diff<
+  {
+    a: string,
+    b: number,
+    ...
+  },
+  { a: any }
+>;
+declare type B = $Diff<
+  {
+    a: string,
+    b: number,
+    ...
+  },
+  { a: any, b: any }
+>;
+declare type O = {
+  a: string,
+  b: number,
+  ...
+};
+declare type U = \\"a\\";
+declare type C = $Diff<O, { [key: U]: any }>;
+"
+`;
+
 exports[`should handle utility types 1`] = `
 "declare type A = $ReadOnly<{
   a: number,

--- a/src/__tests__/interface-exports.spec.ts
+++ b/src/__tests__/interface-exports.spec.ts
@@ -10,3 +10,15 @@ it("should handle exported interfaces", () => {
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle exported interfaces within a module", () => {
+  const ts = `declare module "my-module" {
+    export interface UnaryFunction<T, R> {
+      (source: T): R;
+    }
+  }
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/__tests__/interfaces.spec.ts
+++ b/src/__tests__/interfaces.spec.ts
@@ -230,3 +230,21 @@ interface ArrayBinding {
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle mutli-extends pattern", () => {
+  const ts = `
+interface Shape {
+  color: string;
+}
+
+interface PenStroke {
+  penWidth: number;
+}
+interface Square extends Shape, PenStroke {
+  sideLength: number;
+}
+`;
+  const result = compiler.compileDefinitionString(ts);
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/__tests__/utility-types.spec.ts
+++ b/src/__tests__/utility-types.spec.ts
@@ -30,3 +30,17 @@ type F2<T, U> = Record<T, U>
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle Omit type", () => {
+  const ts = `
+type A = Omit<{ a: string, b: number }, "a">
+type B = Omit<{ a: string, b: number }, "a" | "b">
+
+type O = { a: string, b: number };
+type U = "a";
+type C = Omit<O, U>;
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -190,6 +190,8 @@ const interfaceHeritageClause = type => {
     if (typeof name === "function") {
       // @ts-expect-error todo(flow->ts)
       return name(type.typeArguments);
+    } else {
+      return name;
     }
   } else {
     return printers.node.printType(type);


### PR DESCRIPTION
**Changes:**
- Partially supports `Omit` (`$Diff<O, {[U]: any}>` is syntactically valid but type checking is not working on flow https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVAXAngBwKZgCqYAvGAEQCG5A3OtvmAIKlgAkAIgJZRQA8AbwA+YSgC4wAZwwAnLgDsA5gBowAIwnyArgFs1eGWCEBfVcLABtQgF0JleViPGAfHVQBjOPOmiJLMgK+FAAWeDDw5KoaYACMYMZ0QA)
- Fix multi-extends interfaces