### PR TITLE
Support React.ReactElement

### DIFF
--- a/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
@@ -14,9 +14,11 @@ declare class Component mixins React.Component<Props> {
 `;
 
 exports[`should handle react types 1`] = `
-"import type { Node } from \\"react\\";
+"import type { Node, Element } from \\"react\\";
 import * as React from \\"react\\";
 declare function s(node: Node): void;
 declare function s(node: React.Node): void;
+declare function s(node: Element<\\"div\\">): void;
+declare function s(node: React.Element<\\"div\\">): void;
 "
 `;

--- a/src/__tests__/module-identifiers.spec.ts
+++ b/src/__tests__/module-identifiers.spec.ts
@@ -3,10 +3,12 @@ import "../test-matchers";
 
 it("should handle react types", () => {
   const ts = `
-import type {ReactNode} from 'react'
+import type {ReactNode, ReactElement} from 'react'
 import * as React from 'react'
 declare function s(node: ReactNode): void;
 declare function s(node: React.ReactNode): void;
+declare function s(node: ReactElement<'div'>): void;
+declare function s(node: React.ReactElement<'div'>): void;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();

--- a/src/printers/smart-identifiers.ts
+++ b/src/printers/smart-identifiers.ts
@@ -13,6 +13,7 @@ const setImportedName = (
     if (name === "react" || name === "React") {
       return {
         ReactNode: "Node",
+        ReactElement: "Element",
       };
     }
     return {};


### PR DESCRIPTION
Similar to React.ReactNode in TypeScript, React.ReactElement should be
updated to React.Element in flow. This adds support for that along with
a test.