### PR TITLE
fix: add "static" keyword in front of static getters

### DIFF
--- a/src/__tests__/__snapshots__/classes.spec.ts.snap
+++ b/src/__tests__/__snapshots__/classes.spec.ts.snap
@@ -21,6 +21,7 @@ declare class Observable<T> mixins Subscribable<T> {
     [key: string]: any,
     ...
   };
+  static fooGet: string;
 }
 "
 `;

--- a/src/__tests__/classes.spec.ts
+++ b/src/__tests__/classes.spec.ts
@@ -22,6 +22,7 @@ it("should handle static methods ES6 classes", () => {
     protected get cfnProperties(): {
       [key: string]: any;
     };
+    static get fooGet(): string;
   }
   `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -854,7 +854,7 @@ export const printType = withEnv<any, [any], string>(
         return printers.relationships.importExportSpecifier(type);
 
       case ts.SyntaxKind.GetAccessor:
-        return printers.common.parameter(type);
+        return keywordPrefix + printers.common.parameter(type);
 
       case ts.SyntaxKind.SetAccessor:
         return printers.common.parameter(type);


### PR DESCRIPTION
[References issue](https://github.com/joarwilk/flowgen/issues/170)

Currently when creating a static getter in a class, the word "static" is left out when code is transpiled to Flow. Flow is then unable to access the property in the class, this CR adds the keyword so that Flow may read the property within the class.

Typescript file
```
export default class Test {
    static get hello(): string;
}
```

BEFORE CHANGE flow file
```
declare export default class Test {
  hello: string;
}
```
AFTER CHANGE flow file
```
declare export default class Test {
  static hello: string;
}
```