### PR TITLE
fix: change Typecript RegExpMatchArray to Flow RegExp$matchResult

### DIFF
--- a/src/__tests__/__snapshots__/basic.spec.ts.snap
+++ b/src/__tests__/__snapshots__/basic.spec.ts.snap
@@ -24,6 +24,7 @@ exports[`should handle basic keywords 1`] = `
   u: Symbol,
   v: [1, 2, 3],
   w: $ReadOnlyArray<string>,
+  x: RegExp$matchResult,
   ...
 };
 "
@@ -53,6 +54,7 @@ exports[`should handle basic keywords 2`] = `
   u: Symbol,
   v: [1, 2, 3],
   w: $ReadOnlyArray<string>,
+  x: RegExp$matchResult,
 |};
 "
 `;

--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -25,6 +25,7 @@ it("should handle basic keywords", () => {
     u: unique symbol,
     v: readonly [1, 2, 3],
     w: readonly string[],
+    x: RegExpMatchArray
   }`;
 
   {

--- a/src/printers/identifiers.ts
+++ b/src/printers/identifiers.ts
@@ -35,6 +35,7 @@ Object.assign(identifiers, {
   ReadonlySet: "$ReadOnlySet",
   ReadonlyMap: "$ReadOnlyMap",
   Readonly: "$ReadOnly",
+  RegExpMatchArray: "RegExp$matchResult",
   NonNullable: "$NonMaybeType",
   Partial: ([type]: any[]) => {
     const isInexact = opts().inexact;


### PR DESCRIPTION
Not sure if I put code in right spot, but this is to add support to [RegExp$matchResult](https://github.com/facebook/flow/blob/v0.170/lib/core.js#L1072) which has been in flow since at least version .100. Currently, if Typescript uses RegExpMatchArray it is not transpiled in Flow and remains RegExpMatchArray which doesn't exist in Flow and should be RegExp$matchResult.



Typescript code
```
export declare const getMatch: (text: string) => RegExpMatchArray;
```

Flow code BEFORE CHANGE
```
declare export var getMatch: (text: string) => RegExpMatchArray;
```

Flow code AFTER CHANGE  
```
declare export var getMatch: (text: string) => RegExp$matchResult;
```
