### PR TITLE
fix: prevent jsdoc see tag from causing crashes

### DIFF
--- a/src/__tests__/__snapshots__/jsdoc.spec.ts.snap
+++ b/src/__tests__/__snapshots__/jsdoc.spec.ts.snap
@@ -41,6 +41,8 @@ declare type F = {
  * @return {?Node} The node if it was updated, its replacedment or null if it
  * was removed.
  * @template
+ * @see https ://thereShouldNotBeASpaceAfterHttps.com
+ * @see HelloWorld
  */
 declare var patchOuter: <T>(
   node: Element,

--- a/src/__tests__/jsdoc.spec.ts
+++ b/src/__tests__/jsdoc.spec.ts
@@ -42,6 +42,8 @@ type F = {
  * @return {?Node} The node if it was updated, its replacedment or null if it
  *     was removed.
  * @template T
+ * @see https://thereShouldNotBeASpaceAfterHttps.com
+ * @see HelloWorld
  */
 declare var patchOuter: <T>(
   node: Element,

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -101,6 +101,7 @@ type PrintNode =
   | ts.JSDocVariadicType
   | ts.JSDocNonNullableType
   | ts.JSDocNullableType
+  | ts.JSDocNameReference
   | ts.ComputedPropertyName
   | ts.OptionalTypeNode
   | ts.GetAccessorDeclaration
@@ -471,7 +472,9 @@ export const printType = withEnv<any, [any], string>(
         return "!" + printType(type.type);
       case ts.SyntaxKind.JSDocNullableType:
         return "?" + printType(type.type);
-
+      case ts.SyntaxKind.JSDocNameReference:
+        // @ts-expect-error todo(flow->ts) - 'escapedText' does not exist on type 'EntityName | JSDocMemberName'
+        return type?.name?.escapedText || "";
       case ts.SyntaxKind.ConditionalType: {
         env.conditionalHelpers = true;
         return `$FlowGen$If<$FlowGen$Assignable<${printType(


### PR DESCRIPTION
Previously the `@see` jsdoc tag would break flowgen compilation - check [References issue](https://github.com/joarwilk/flowgen/issues/147)

This adds some support for the `@see` tag, though there are still some issues (see https example in test). Overall, though I think it's an improvement since it prevents crashing and there are still a lot of other jsdoc issues as other complimentary tags like @link do not work.

Example of LINK tag not working (NOT AFFECTED BY THIS CHANGE)
```
/**
 * See {@link MyClass} and [MyClass's foo property]{@link MyClass#foo}.
 * Also, check out {@link http://www.google.com|Google} and
 * {@link https://github.com GitHub}.
 */
export declare function myFunction(): void;
```
Output by flowgen
```
/**
 * [object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]
 */
declare export function myFunction(): void;
```