### PR TITLE
docs: replace deprecated Utility Types as of Flow 0.155

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It's surprisingly robust and non-lossy as it stands right now, in big part thank
 |    | InstanceType | `InstanceType<X>` |  |
 |    | Required | `Required<X>` |  |
 |    | ThisType | `ThisType<X>` |  |
-| ✅ | T['string'] | `T['string']` | `$PropertyType<T, k>` |
+| ✅ | T['string'] | `T['string']` | `T['k']` |
 | ✅ | T[k] | `T[k]` | `$ElementType<T, k>` |
 | ✅ | Mapped types | `{[K in keyof Obj]: Obj[K]}` | `$ObjMapi<Obj, <K>(K) => $ElementType<Obj, K>>` |
 |    | Conditional types | `A extends B ? C : D` | `any` |


### PR DESCRIPTION
WARNING: $PropertyType is deprecated as of Flow version 0.155, and will be removed in a future version of Flow. Use Indexed Access Types instead. $PropertyType<T, 'k'> is now T['k'].

https://flow.org/en/docs/types/utilities/#toc-propertytype