### PR TITLE
fix type exports in typescript 4.5

### DIFF
--- a/src/__tests__/__snapshots__/type-exports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/type-exports.spec.ts.snap
@@ -30,3 +30,19 @@ export type Maybe<T> =
     };
 "
 `;
+
+exports[`should handle inline export list syntax 1`] = `
+"declare type ComplexType =
+  | {
+      type: number,
+      ...
+    }
+  | {
+      type: string,
+      ...
+    };
+declare var foo: 5;
+export type { ComplexType };
+declare export { foo };
+"
+`;

--- a/src/__tests__/type-exports.spec.ts
+++ b/src/__tests__/type-exports.spec.ts
@@ -26,3 +26,18 @@ export { foo };
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle inline export list syntax", () => {
+  const ts = `
+declare type ComplexType = {
+    type: number
+} | {
+    type: string
+};
+const foo = 5;
+export { type ComplexType, foo };
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});


### PR DESCRIPTION
Typescript 4.5 adds [type modifiers for import / export lists](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names).

This PR addresses that for export lists by keeping most of the code the same, but using the `type` keyword to split value lists. Since I don't think flow has a corresponding syntax, it's currently split into two export declarations if such a list exists.

Caveats:
- I'm not an expert in flow or this library so harsh critique is welcome
- This syntax applies to import as well. I only need support for export, so that's all I've added, but if you really want I can look into full support
- I saw a todo to abstract printing into the printers module. I don't really want to do that in this PR, but a plus is in the current form, this PR doesn't seem to make that any harder