### PR TITLE
Handle `import(…)` types for non-builtin modules, too

### DIFF
--- a/src/__tests__/__snapshots__/import.spec.ts.snap
+++ b/src/__tests__/__snapshots__/import.spec.ts.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle dynamic imports 1`] = `
-"declare type A = $Exports<\\"react\\">;
-declare type B = $PropertyType<$Exports<\\"react\\">, \\"ReactNode\\">;
+"import * as $Flowgen$Import$react from \\"react\\";
+import * as $Flowgen$Import$zlib from \\"zlib\\";
+declare type A = typeof $Flowgen$Import$react;
+declare type B = $Flowgen$Import$react.Node;
+declare type C = $Flowgen$Import$react.ComponentType<{ ... }>;
+declare type D = $Flowgen$Import$zlib.Zlib;
+"
+`;
+
+exports[`should handle import nested in type arguments of import 1`] = `
+"import * as $Flowgen$Import$react from \\"react\\";
+declare type A = $Flowgen$Import$react.ComponentType<
+  $Flowgen$Import$react.ComponentType<any>
+>;
+"
+`;
+
+exports[`should handle imports from odd names 1`] = `
+"import * as $Flowgen$Import$_2e__2e_ from \\"..\\";
+import * as $Flowgen$Import$_40__21__2d__2f__2e__2f_ from \\"@!-/./\\";
+declare type A = typeof $Flowgen$Import$_2e__2e_;
+declare type B = typeof $Flowgen$Import$_40__21__2d__2f__2e__2f_;
 "
 `;

--- a/src/__tests__/__snapshots__/imports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/imports.spec.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle import type 1`] = `
-"declare type S = $Exports<\\"http\\">;
+"import * as $Flowgen$Import$http from \\"http\\";
+declare type S = typeof $Flowgen$Import$http;
 "
 `;
 

--- a/src/__tests__/import.spec.ts
+++ b/src/__tests__/import.spec.ts
@@ -3,8 +3,38 @@ import "../test-matchers";
 
 it("should handle dynamic imports", () => {
   const ts = `
+// whole module
 type A = import('react');
+
+// type alias inside module
 type B = import('react').ReactNode;
+
+// generic type alias inside module, with type arguments
+type C = import('react').ComponentType<{}>;
+
+// class inside module
+type D = import('zlib').Zlib;
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should handle imports from odd names", () => {
+  const ts = `
+type A = import('..');
+type B = import('@!-/./');
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  // expect(result).toBeValidFlowTypeDeclarations(); // would need actual modules at those names
+});
+
+it("should handle import nested in type arguments of import", () => {
+  // In other words, test that our visitor for this feature didn't forget to
+  // visit the type arguments in the case where it's rewriting something.
+  const ts = `
+type A = import("react").ComponentType<import("react").ComponentType<any>>;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();

--- a/src/cli/compiler.ts
+++ b/src/cli/compiler.ts
@@ -1,4 +1,4 @@
-import {
+import ts, {
   createProgram,
   createCompilerHost,
   createSourceFile,
@@ -64,12 +64,14 @@ const transformFile = (
   languageVersion: ScriptTarget,
   options?: Options,
 ) => {
-  return transform(
+  const transformedAst = transform(
     //$todo Flow has problems when switching variables instead of literals
     createSourceFile(fileName, sourceText, languageVersion, true),
     getTransformers(options),
     compilerOptions,
   ).transformed[0];
+  const transformedText = ts.createPrinter().printFile(transformedAst);
+  return createSourceFile(fileName, transformedText, languageVersion, true);
 };
 
 /**

--- a/src/cli/compiler.ts
+++ b/src/cli/compiler.ts
@@ -47,6 +47,11 @@ const reset = (options?: Options): void => {
   namespaceManager.reset();
 };
 
+const compilerOptions = {
+  noLib: true,
+  target: ScriptTarget.Latest,
+};
+
 const getTransformers = (options?: Options) => [
   legacyModules(),
   importEqualsTransformer(),
@@ -76,10 +81,6 @@ export default {
   compileDefinitionString: (string: string, options?: Options): string => {
     reset(options);
 
-    const compilerOptions = {
-      noLib: true,
-      target: ScriptTarget.Latest,
-    };
     const compilerHost = createCompilerHost({}, true);
     const oldSourceFile = compilerHost.getSourceFile;
     compilerHost.getSourceFile = (file, languageVersion) => {
@@ -116,10 +117,6 @@ export default {
   ): string => {
     reset(options);
 
-    const compilerOptions = {
-      noLib: true,
-      target: ScriptTarget.Latest,
-    };
     const compilerHost = createCompilerHost({}, true);
     const oldSourceFile = compilerHost.getSourceFile;
     const oldReadFile = compilerHost.readFile;
@@ -162,10 +159,6 @@ export default {
       fileName: string,
     ) => string | undefined = a => a,
   ): Array<[string, string]> => {
-    const compilerOptions = {
-      noLib: true,
-      target: ScriptTarget.Latest,
-    };
     const compilerHost = createCompilerHost({}, true);
     const oldSourceFile = compilerHost.getSourceFile;
     const oldReadFile = compilerHost.readFile;

--- a/src/cli/compiler.ts
+++ b/src/cli/compiler.ts
@@ -58,6 +58,20 @@ const getTransformers = (options?: Options) => [
   declarationFileTransform(options),
 ];
 
+const transformFile = (
+  fileName: string,
+  sourceText: string,
+  languageVersion: ScriptTarget,
+  options?: Options,
+) => {
+  return transform(
+    //$todo Flow has problems when switching variables instead of literals
+    createSourceFile(fileName, sourceText, languageVersion, true),
+    getTransformers(options),
+    compilerOptions,
+  ).transformed[0];
+};
+
 /**
  * Compiles typescript files
  */
@@ -85,12 +99,7 @@ export default {
     const oldSourceFile = compilerHost.getSourceFile;
     compilerHost.getSourceFile = (file, languageVersion) => {
       if (file === "file.ts") {
-        return transform(
-          //$todo Flow has problems when switching variables instead of literals
-          createSourceFile("/dev/null", string, languageVersion, true),
-          getTransformers(options),
-          compilerOptions,
-        ).transformed[0];
+        return transformFile("/dev/null", string, languageVersion, options);
       }
       return oldSourceFile(file, languageVersion);
     };
@@ -124,17 +133,8 @@ export default {
       mapSourceCode(oldReadFile(fileName), fileName);
     compilerHost.getSourceFile = (file, languageVersion) => {
       if (file === path) {
-        return transform(
-          //$todo Flow has problems when switching variables instead of literals
-          createSourceFile(
-            file,
-            compilerHost.readFile(file),
-            languageVersion,
-            true,
-          ),
-          getTransformers(options),
-          compilerOptions,
-        ).transformed[0];
+        const sourceText = compilerHost.readFile(file);
+        return transformFile(file, sourceText, languageVersion, options);
       }
       return oldSourceFile(file, languageVersion);
     };
@@ -166,17 +166,8 @@ export default {
       mapSourceCode(oldReadFile(fileName), fileName);
     compilerHost.getSourceFile = (file, languageVersion) => {
       if (paths.includes(file)) {
-        return transform(
-          //$todo Flow has problems when switching variables instead of literals
-          createSourceFile(
-            file,
-            compilerHost.readFile(file),
-            languageVersion,
-            true,
-          ),
-          getTransformers(options),
-          compilerOptions,
-        ).transformed[0];
+        const sourceText = compilerHost.readFile(file);
+        return transformFile(file, sourceText, languageVersion, options);
       }
       return oldSourceFile(file, languageVersion);
     };

--- a/src/cli/compiler.ts
+++ b/src/cli/compiler.ts
@@ -18,6 +18,7 @@ import {
   importEqualsTransformer,
   legacyModules,
   declarationFileTransform,
+  importTypeToImportDeclaration,
 } from "../parse/transformers";
 import { recursiveWalkTree } from "../parse";
 import { printFlowGenHelper } from "../printers/node";
@@ -56,6 +57,7 @@ const getTransformers = (options?: Options) => [
   legacyModules(),
   importEqualsTransformer(),
   declarationFileTransform(options),
+  importTypeToImportDeclaration(),
 ];
 
 const transformFile = (

--- a/src/errors/error-message.ts
+++ b/src/errors/error-message.ts
@@ -28,6 +28,10 @@ export type ErrorMessage =
       readonly description: string;
     }
   | {
+      readonly type: "FlowgenInternalError";
+      readonly description: string;
+    }
+  | {
       readonly type: "MissingFunctionName";
     };
 
@@ -59,6 +63,9 @@ export function printErrorMessage(error: ErrorMessage): string {
 
     case "UnexpectedTsSyntax":
       return `Unexpected TypeScript syntax: ${error.description}. Please report this at https://github.com/joarwilk/flowgen/issues`;
+
+    case "FlowgenInternalError":
+      return `Flowgen internal error: ${error.description}. Please report this at https://github.com/joarwilk/flowgen/issues`;
 
     default:
       error as never;

--- a/src/errors/error-message.ts
+++ b/src/errors/error-message.ts
@@ -24,6 +24,10 @@ export type ErrorMessage =
       readonly operator: typeof SyntaxKind[keyof typeof SyntaxKind];
     }
   | {
+      readonly type: "UnexpectedTsSyntax";
+      readonly description: string;
+    }
+  | {
       readonly type: "MissingFunctionName";
     };
 
@@ -52,6 +56,9 @@ export function printErrorMessage(error: ErrorMessage): string {
 
     case "UnsupportedTypeOperator":
       return `Unsupported type operator: ${SyntaxKind[error.operator]}`;
+
+    case "UnexpectedTsSyntax":
+      return `Unexpected TypeScript syntax: ${error.description}. Please report this at https://github.com/joarwilk/flowgen/issues`;
 
     default:
       error as never;

--- a/src/parse/transformers.ts
+++ b/src/parse/transformers.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { stripDetailsFromTree } from "./ast";
 import type { Options } from "../options";
+import * as logger from "../logger";
 
 function updatePos<T extends ts.Node>(node: T) {
   // @ts-expect-error todo: modifying "readonly" property
@@ -114,6 +115,152 @@ export function declarationFileTransform(options?: Options) {
           ),
         ),
       ]);
+    };
+    return visitor;
+  }
+  return (ctx: ts.TransformationContext): ts.Transformer<any> => {
+    return (sf: ts.SourceFile) => ts.visitNode(sf, visitor(ctx));
+  };
+}
+
+/** Like `ctx.factory.createQualifiedName`, but put identifier at start instead of end. */
+function prependIdentifier(
+  ctx: ts.TransformationContext,
+  id: ts.Identifier,
+  qualifier: ts.EntityName | undefined,
+): ts.EntityName {
+  if (!qualifier) {
+    return id;
+  } else if (qualifier.kind === ts.SyntaxKind.Identifier) {
+    return ctx.factory.createQualifiedName(id, qualifier);
+  } else {
+    return ctx.factory.createQualifiedName(
+      prependIdentifier(ctx, id, qualifier.left),
+      qualifier.right,
+    );
+  }
+}
+
+/**
+ * Make a deterministic, unique, JS-valid identifier based on the given string.
+ *
+ * The result is a string which begins with `prefix` and can be used as a
+ * JavaScript identifier name.  It's always the same when called with the
+ * same arguments, and always different when called with different
+ * arguments.
+ *
+ * The argument `prefix` is required to be a valid JS identifier name.
+ */
+function escapeNameAsIdentifierWithPrefix(
+  prefix: string,
+  name: string,
+): string {
+  // The set of valid JS identifier names is defined here:
+  //   https://tc39.es/ecma262/#prod-IdentifierName
+  // In particular, after the first character, each character can be `$`
+  // or any character with the `ID_Continue` Unicode property, among others.
+
+  // For our construction:
+  //  * Characters in `name` with `ID_Continue`, other than `_`, we use
+  //    verbatim.
+  //  * Other characters we replace with an escape sequence, marked by `_`.
+  // This provides a string where all characters have `ID_Continue`, as an
+  // invertible function of `name`.
+  const escapedName = name.replace(
+    /\P{ID_Continue}|_/gu,
+    c => `_${c.codePointAt(0).toString(16)}_`,
+  );
+  // This escaping always gives different results for different inputs,
+  // because the following code would reconstruct the input:
+  //   assert(
+  //     name ===
+  //       escapedName.replace(/_[^_]*_/g, s =>
+  //         String.fromCodePoint(Number.parseInt(s.substring(1), 16)),
+  //       ),
+  //   );
+
+  // Then we delimit the prefix from the escaped name with `$`, which lacks
+  // `ID_Continue` and therefore cannot appear in the escaped name.
+  return prefix + "$" + escapedName;
+}
+
+/**
+ * Rewrite `import(…)` types into full import declarations.
+ *
+ * Flow doesn't have an equivalent to `import(…)` types.
+ */
+export function importTypeToImportDeclaration() {
+  function visitor(ctx: ts.TransformationContext) {
+    const imports = new Map();
+    const visitor: ts.Visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      if (ts.isImportTypeNode(node)) {
+        if (
+          !ts.isLiteralTypeNode(node.argument) ||
+          !ts.isStringLiteral(node.argument.literal)
+        ) {
+          // TS (as of 4.6.2) gives an error if the argument to `import(…)`
+          // isn't a string literal, saying "String literal expected."
+          // So this case should be impossible.
+          logger.error(node, {
+            type: "UnexpectedTsSyntax",
+            description: "import(…) type with argument not a string literal",
+          });
+          return ts.visitEachChild(node, visitor, ctx);
+        }
+
+        const importSource = node.argument.literal.text;
+        let identifier;
+        if (!imports.has(importSource)) {
+          identifier = ctx.factory.createIdentifier(
+            escapeNameAsIdentifierWithPrefix("$Flowgen$Import", importSource),
+          );
+          // Construct an import statement like this:
+          //   import * as ${identifier} from ${node.argument};
+          const decl = ctx.factory.createImportDeclaration(
+            undefined,
+            undefined,
+            ctx.factory.createImportClause(
+              false,
+              undefined,
+              ctx.factory.createNamespaceImport(identifier),
+            ),
+            node.argument.literal,
+          );
+          imports.set(importSource, { identifier, decl });
+        } else {
+          identifier = imports.get(importSource).identifier;
+        }
+
+        if (!node.qualifier) {
+          // The reference is to the module as a whole, as a type.
+          // Must need a `typeof`.
+          if (node.typeArguments)
+            throw new Error(
+              "impossible syntax: type arguments applied to a module",
+            );
+          return ctx.factory.createTypeOfExpression(identifier);
+        } else {
+          // The reference is to something inside the module.
+          return ctx.factory.createTypeReferenceNode(
+            prependIdentifier(ctx, identifier, node.qualifier),
+            ts.visitNodes(node.typeArguments, visitor),
+          );
+        }
+      }
+
+      if (ts.isSourceFile(node)) {
+        const visited = ts.visitEachChild(node, visitor, ctx);
+        if (!imports.size) {
+          return visited;
+        }
+        return ctx.factory.updateSourceFile(visited, [
+          // @ts-expect-error
+          ...[...imports.values()].map(v => v.decl),
+          ...visited.statements,
+        ]);
+      }
+
+      return ts.visitEachChild(node, visitor, ctx);
     };
     return visitor;
   }

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -398,6 +398,21 @@ export function fixDefaultTypeArguments(
   }
 }
 
+/**
+ * Log an error, while returning a commented FlowFixMe type.
+ *
+ * This is appropriate for error conditions that indicate a bug within
+ * Flowgen.
+ *
+ * The error uses `logger.error` for a nice message pointing at the input
+ * source code corresponding to `node`, to help identify what triggered the
+ * issue.
+ */
+const printErrorType = (description: string, node: ts.Node) => {
+  logger.error(node, { type: "FlowgenInternalError", description });
+  return `($FlowFixMe /* flowgen-error: ${description} */)`;
+};
+
 export const printType = withEnv<any, [any], string>(
   (env: any, rawType: any): string => {
     // debuggerif()
@@ -604,14 +619,7 @@ export const printType = withEnv<any, [any], string>(
         return type.text;
 
       case ts.SyntaxKind.ImportType:
-        // @ts-expect-error todo(flow->ts)
-        if (type.qualifier?.escapedText) {
-          return `$PropertyType<$Exports<${printType(
-            type.argument,
-            // @ts-expect-error todo(flow->ts)
-          )}>, ${JSON.stringify(type.qualifier.escapedText)}>`;
-        }
-        return `$Exports<${printType(type.argument)}>`;
+        return printErrorType("Failed to transform an ImportType node", type);
 
       case ts.SyntaxKind.FirstTypeNode:
         return printers.common.literalType(type);


### PR DESCRIPTION
We've been handling TypeScript's `import(…)` feature by rewriting it
to Flow's `$Exports` utility type.

However, it turns out that `$Exports` only works when the module it
refers to was defined *in a libdef*, as a builtin.  It doesn't work if
the module was defined in a `.js.flow` file, or a normal `.js` file.
That's OK for `import('react')` or `import('http')`; but when a
TypeScript library uses `import(…)` to refer to its own modules, this
means we generate broken output when trying to turn its `.d.ts` files
into `.js.flow` files.

Happily, we can completely resolve the issue by rewriting `import(…)`
into a reference to a normal `import * as … from …` declaration.

---

That limitation of `$Exports` sadly isn't in its Flow documentation:
  https://flow.org/en/docs/types/utilities/#toc-exports

But it's explained in this commit message which introduced the
limitation, in Flow v0.123.0:
  https://github.com/facebook/flow/commit/3182f731a0
and briefly mentioned in the changelog:
  https://github.com/facebook/flow/blob/main/Changelog.md#01230

(From that commit message, it sounds like `$Exports` already didn't
completely work in this case, but I'm not sure exactly how.)
