### PR TITLE
Clear up a few `any` types

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -23,8 +23,8 @@ export type Compiler = {|
 
   // Low-level exports
   reset(options?: Options): void,
-  setChecker(checker: any): void,
-  compile(sourceFile: any): string,
+  setChecker(checker: $FlowFixMe /* ts.TypeChecker */): void,
+  compile(sourceFile: $FlowFixMe /* ts.SourceFile */): string,
 |};
 
 declare type Flowgen = {|

--- a/src/cli/compiler.ts
+++ b/src/cli/compiler.ts
@@ -1,4 +1,4 @@
-import {
+import ts, {
   createProgram,
   createCompilerHost,
   createSourceFile,
@@ -61,7 +61,7 @@ export default {
 
   compile: compile.withEnv({}),
 
-  setChecker(typeChecker: any) {
+  setChecker(typeChecker: ts.TypeChecker) {
     checker.current = typeChecker;
   },
 


### PR DESCRIPTION
The `any` types in the index.js.flow file, combined with the
`@flow strict` at the top, cause Flow to give errors when run
with a typical `.flowconfig`, one with the recommended set of
lints under `[strict]`.

That in turn happens when running Flow on a project that uses
this one, if using `yarn link` to use a checkout of the Flowgen
repo instead of a copy of the built artifact from NPM.  Which is
a handy thing to do when developing changes to Flowgen and
testing them in a project that uses it.

Instead, to avoid those errors, we can just say `$FlowFixMe`.
It has the same semantics as `any`, but because it explicitly
acknowledges that something's missing, the strict-mode linters
don't complain about it.

Also add tiny comments to indicate what the types are really
supposed to be.  While looking those up, we find that one of
them is `any` in the actual implementation, but easily fixed;
fix that too.