### PR TITLE
logger: Avoid crashing when filename longer than terminal width

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -16,6 +16,10 @@ export function setSourceFile(file: SourceFile): void {
   sourceFile.current = file;
 }
 
+function padDashes(consumedWidth: number) {
+  return "-".repeat(Math.max(4, process.stdout.columns - consumedWidth));
+}
+
 export function error(node: any, message: ErrorMessage): void {
   if (opts().quiet) return;
   const options = {
@@ -47,8 +51,8 @@ export function error(node: any, message: ErrorMessage): void {
     const fileName = path.relative(process.cwd(), currentSourceFile.fileName);
     console.log(
       chalk.red.bold(
-        `Error ${"-".repeat(
-          process.stdout.columns - 7 - fileName.length - position.length,
+        `Error ${padDashes(
+          7 + fileName.length + position.length,
         )} ${fileName}${position}`,
       ),
     );


### PR DESCRIPTION
Without this, if we call `logger.error` and the source file we're
currently acting on has a long name, we attempt to use a negative
number of `-` characters here, and end up crashing with an error like:

```
RangeError: Invalid count value
    at String.repeat (<anonymous>)
    at Object.error (…/flowgen/lib/logger.js:55:45)
    at …/flowgen/lib/printers/node.js:478:16
    at Object.fn (…/flowgen/lib/env.js:10:12)
    at Object.propertyDeclaration (…/flowgen/lib/printers/declarations.js:46:31)
    at …/flowgen/lib/printers/node.js:551:36
    at fn (…/flowgen/lib/env.js:10:12)
    at Array.map (<anonymous>)
    at parseNameFromNode (…/flowgen/lib/parse/ast.js:41:86)
    at collectNode (…/flowgen/lib/parse/index.js:67:51)
```