### PR TITLE
Add some type annotations replacing `any`, mostly in src/printers/

### DIFF
--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -107,7 +107,7 @@ async function bfs(
   while (queue.length) {
     current = queue.shift();
     try {
-      const dir: Array<any> = await readDir(current, { withFileTypes: true });
+      const dir = await readDir(current, { withFileTypes: true });
       for (const file of dir) {
         if (file.isDirectory()) {
           if (file.name === "node_modules") continue;

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,7 +1,7 @@
 let i = 0;
 const envs = {};
 
-export function withEnv<Env, A extends ReadonlyArray<any>, B>(
+export function withEnv<Env, A extends ReadonlyArray<unknown>, B>(
   callback: (env: Env, ...args: A) => B,
 ): {
   withEnv<T>(env: T): (...args: A) => B;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,11 +1,11 @@
 import type { SourceFile } from "typescript";
+import ts from "typescript";
 import { opts } from "./options";
 import path from "path";
 import { codeFrameColumns } from "@babel/code-frame";
 import { getChalk } from "@babel/highlight";
 
 import { printErrorMessage } from "./errors/error-message";
-
 import type { ErrorMessage } from "./errors/error-message";
 
 const sourceFile: {
@@ -20,7 +20,7 @@ function padDashes(consumedWidth: number) {
   return "-".repeat(Math.max(4, process.stdout.columns - consumedWidth));
 }
 
-export function error(node: any, message: ErrorMessage): void {
+export function error(node: ts.Node, message: ErrorMessage): void {
   if (opts().quiet) return;
   const options = {
     highlightCode: true,

--- a/src/printers/common.ts
+++ b/src/printers/common.ts
@@ -96,7 +96,9 @@ export const parameter = (param: RawNode): string => {
   return `${left}: ${right}`;
 };
 
-export const methodSignature = (param: RawNode): string => {
+export const methodSignature = (
+  param: ts.MethodSignature | ts.MethodDeclaration,
+): string => {
   let left = "";
   let isMethod = true;
   if (param.modifiers) {

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -156,13 +156,17 @@ const interfaceRecordType = (
   }
 };
 
-const classHeritageClause = withEnv<any, any, string>((env, type) => {
-  let ret;
+const classHeritageClause = withEnv<
+  any,
+  [ts.ExpressionWithTypeArguments],
+  string
+>((env, type) => {
+  let ret: string;
   env.classHeritage = true;
   // TODO: refactor this
   const symbol = checker.current.getSymbolAtLocation(type.expression);
   printers.node.fixDefaultTypeArguments(symbol, type);
-  if (type.expression.kind === ts.SyntaxKind.Identifier && symbol) {
+  if (ts.isIdentifier(type.expression) && symbol) {
     ret =
       printers.node.getFullyQualifiedPropertyAccessExpression(
         symbol,
@@ -314,7 +318,7 @@ export const typeReference = (node: RawNode, identifier: boolean): string => {
 
 export const classDeclaration = <T>(
   nodeName: string,
-  node: RawNode,
+  node: ts.ClassDeclaration,
   mergedNamespaceChildren: ReadonlyArray<Node<T>>,
 ): string => {
   let heritage = "";

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -26,7 +26,7 @@ type ExpectedKeywordKind =
   | ts.SyntaxKind.TrueKeyword;
 
 type PrintNode =
-  | { kind: ExpectedKeywordKind }
+  | ts.KeywordToken<ExpectedKeywordKind>
   | { kind: typeof ts.SyntaxKind.FirstLiteralToken }
   | ts.CallSignatureDeclaration
   | ts.ConstructorDeclaration

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -9,55 +9,25 @@ import { renames, getLeftMostEntityName } from "./smart-identifiers";
 import { printErrorMessage } from "../errors/error-message";
 import { opts } from "../options";
 
-type KeywordNode =
-  | {
-      kind: typeof ts.SyntaxKind.AnyKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.UnknownKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.NumberKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.BigIntKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.ObjectKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.BooleanKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.StringKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.SymbolKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.VoidKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.UndefinedKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.NullKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.NeverKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.FalseKeyword;
-    }
-  | {
-      kind: typeof ts.SyntaxKind.TrueKeyword;
-    };
+type ExpectedKeywordKind =
+  | ts.SyntaxKind.AnyKeyword
+  | ts.SyntaxKind.UnknownKeyword
+  | ts.SyntaxKind.NumberKeyword
+  | ts.SyntaxKind.BigIntKeyword
+  | ts.SyntaxKind.ObjectKeyword
+  | ts.SyntaxKind.BooleanKeyword
+  | ts.SyntaxKind.StringKeyword
+  | ts.SyntaxKind.SymbolKeyword
+  | ts.SyntaxKind.VoidKeyword
+  | ts.SyntaxKind.UndefinedKeyword
+  | ts.SyntaxKind.NullKeyword
+  | ts.SyntaxKind.NeverKeyword
+  | ts.SyntaxKind.FalseKeyword
+  | ts.SyntaxKind.TrueKeyword;
 
 type PrintNode =
-  | KeywordNode
-  | {
-      kind: typeof ts.SyntaxKind.FirstLiteralToken;
-    }
+  | { kind: ExpectedKeywordKind }
+  | { kind: typeof ts.SyntaxKind.FirstLiteralToken }
   | ts.CallSignatureDeclaration
   | ts.ConstructorDeclaration
   | ts.TypeParameterDeclaration

--- a/src/printers/smart-identifiers.ts
+++ b/src/printers/smart-identifiers.ts
@@ -68,9 +68,9 @@ export function renames(
 ): boolean {
   if (!symbol) return false;
   if (!symbol.declarations) return false;
-  // todo(flow->ts)
-  const decl: any = symbol.declarations[0];
+  const decl = symbol.declarations[0];
   if (ts.isImportSpecifier(type)) {
+    // @ts-expect-error todo(flow->ts)
     setImportedName(decl.name.escapedText, decl.name, symbol, decl);
   } else if (type.kind === ts.SyntaxKind.TypeReference) {
     const leftMost = getLeftMostEntityName(type.typeName);

--- a/src/printers/smart-identifiers.ts
+++ b/src/printers/smart-identifiers.ts
@@ -55,12 +55,15 @@ const setGlobalName = (type: any, _symbol): boolean => {
   return false;
 };
 
-export function renames(symbol: ts.Symbol | void, type: any): boolean {
+export function renames(
+  symbol: ts.Symbol | void,
+  type: ts.TypeReferenceNode | ts.ImportSpecifier,
+): boolean {
   if (!symbol) return false;
   if (!symbol.declarations) return false;
   // todo(flow->ts)
   const decl: any = symbol.declarations[0];
-  if (type.parent && ts.isNamedImports(type.parent)) {
+  if (ts.isImportSpecifier(type)) {
     setImportedName(decl.name.escapedText, decl.name, symbol, decl);
   } else if (type.kind === ts.SyntaxKind.TypeReference) {
     const leftMost = getLeftMostEntityName(type.typeName);
@@ -71,7 +74,7 @@ export function renames(symbol: ts.Symbol | void, type: any): boolean {
         return setGlobalName(type, symbol);
       }
     }
-    if (type.typeName.right) {
+    if (ts.isQualifiedName(type.typeName)) {
       return setImportedName(
         symbol.escapedName,
         type.typeName.right,

--- a/src/printers/smart-identifiers.ts
+++ b/src/printers/smart-identifiers.ts
@@ -95,7 +95,7 @@ export function renames(
   return false;
 }
 
-export function getLeftMostEntityName(type: ts.EntityName) {
+export function getLeftMostEntityName(type: ts.EntityName): ts.Identifier {
   if (type.kind === ts.SyntaxKind.QualifiedName) {
     return type.left.kind === ts.SyntaxKind.Identifier
       ? type.left

--- a/src/printers/smart-identifiers.ts
+++ b/src/printers/smart-identifiers.ts
@@ -35,7 +35,10 @@ const setImportedName = (
   return false;
 };
 
-const setGlobalName = (type: any, _symbol): boolean => {
+const setGlobalName = (
+  type: ts.TypeReferenceNode,
+  _symbol: ts.Symbol,
+): boolean => {
   const globals = [
     {
       from: ts.createQualifiedName(ts.createIdentifier("JSX"), "Element"),
@@ -45,7 +48,11 @@ const setGlobalName = (type: any, _symbol): boolean => {
   if (checker.current) {
     const bools = [];
     for (const { from, to } of globals) {
-      if (compareQualifiedName(type.typeName, from)) {
+      if (
+        ts.isQualifiedName(type.typeName) &&
+        compareQualifiedName(type.typeName, from)
+      ) {
+        // @ts-expect-error readonly property, but we write to it
         type.typeName = to;
         bools.push(true);
       }
@@ -124,7 +131,6 @@ function compareQualifiedName(
   a: ts.QualifiedName,
   b: ts.QualifiedName,
 ): boolean {
-  if (a.kind !== b.kind) return false;
   return (
     compareEntityName(a.left, b.left) && compareIdentifier(a.right, b.right)
   );


### PR DESCRIPTION
While exploring the codebase to develop changes, I found myself wanting to know what I could expect to be the actual types of various things that are currently annotated as `any`. Given what this project is about, probably anyone reading this needs no persuasion on that point. :slightly_smiling_face: So I figured I'd write down some results as type annotations and share them.

These changes are probably easiest to review commit by commit, rather than the whole diff together -- each commit is small and generally has an explanation of why the type is right. Of course one important check is just the fact that the type-checker still accepts the code; but given that there are `any` types elsewhere in the codebase, I also carefully looked at the call sites of functions (etc.) to confirm that the arguments being passed aren't themselves `any`, and instead have real types which I used to determine what type to write on the function parameter.

(Where the call sites do use `any`, I figure it'll be better to take care of those callers first. This PR contains a couple of chains like that, of annotating first a caller and then its callees.)

For some of these, note that `RawNode` is another name for `any`.
