### PR TITLE
Add more type annotations replacing `any`, mostly in src/printers/

### DIFF
--- a/src/nodes/namespace.ts
+++ b/src/nodes/namespace.ts
@@ -88,6 +88,7 @@ export default class Namespace extends Node {
     }
 
     const childrenDeclarations = this.functions
+      // @ts-expect-error The .raw on a this.functions node is a ts.FunctionDeclaration.
       .map(propNode => printers.functions.functionType(propNode.raw, true))
       .concat(Namespace.formatChildren(children, name));
 

--- a/src/nodes/property.ts
+++ b/src/nodes/property.ts
@@ -68,9 +68,7 @@ export default class Property extends Node<PropertyNode> {
       name = namespace + "$" + name;
     }
 
-    if (this.raw.jsDoc) {
-      out += printers.common.comment(this.raw.jsDoc);
-    }
+    out += printers.common.jsdoc(this.raw);
 
     const isDeclare = mod !== "root";
     const exporter = printers.relationships.exporter(this.raw);

--- a/src/nodes/property.ts
+++ b/src/nodes/property.ts
@@ -1,4 +1,3 @@
-import type { RawNode } from "./node";
 import type {
   FunctionDeclaration,
   ClassDeclaration,
@@ -6,7 +5,6 @@ import type {
   TypeAliasDeclaration,
   EnumDeclaration,
   VariableStatement,
-  JSDoc,
 } from "typescript";
 import * as ts from "typescript";
 import Node from "./node";
@@ -16,36 +14,18 @@ import namespaceManager from "../namespace-manager";
 import { parseNameFromNode } from "../parse/ast";
 
 type PropertyNode =
-  | ({
-      //kind: "FunctionDeclaration",
-      jsDoc: Array<JSDoc>;
-    } & FunctionDeclaration)
-  | ({
-      //kind: "ClassDeclaration",
-      jsDoc: Array<JSDoc>;
-    } & ClassDeclaration)
-  | ({
-      //kind: "InterfaceDeclaration",
-      jsDoc: Array<JSDoc>;
-    } & InterfaceDeclaration)
-  | ({
-      //kind: "TypeAliasDeclaration",
-      jsDoc: Array<JSDoc>;
-    } & TypeAliasDeclaration)
-  | ({
-      //kind: "EnumDeclaration",
-      jsDoc: Array<JSDoc>;
-    } & EnumDeclaration)
-  | ({
-      //kind: "VariableStatement",
-      jsDoc: Array<JSDoc>;
-    } & VariableStatement);
+  | FunctionDeclaration
+  | ClassDeclaration
+  | InterfaceDeclaration
+  | TypeAliasDeclaration
+  | EnumDeclaration
+  | VariableStatement;
 
 export default class Property extends Node<PropertyNode> {
   name: string;
   skip: boolean;
 
-  constructor(node: RawNode) {
+  constructor(node: PropertyNode) {
     super(node);
 
     this.name = parseNameFromNode(node);
@@ -114,7 +94,7 @@ export default class Property extends Node<PropertyNode> {
       case ts.SyntaxKind.VariableStatement:
         for (const decl of this.raw.declarationList.declarations) {
           if (namespace && decl.name.kind === ts.SyntaxKind.Identifier) {
-            const text = (decl.name as any).text;
+            const text = decl.name.text;
             namespaceManager.registerProp(namespace, text);
           }
         }

--- a/src/printers/common.ts
+++ b/src/printers/common.ts
@@ -135,16 +135,6 @@ export const methodSignature = (
   return `${left}${isMethod ? "" : ": "}${right}`;
 };
 
-export const parseTypeReference = (node: RawNode): string => {
-  if (node.typeName.left && node.typeName.right) {
-    return (
-      printers.node.printType(node.typeName) + generics(node.typeArguments)
-    );
-  }
-
-  return node.typeName.text + generics(node.typeArguments);
-};
-
 export const generics = (
   types?: ReadonlyArray<RawNode> | null,
   map: (node: RawNode) => RawNode = node => node,

--- a/src/printers/common.ts
+++ b/src/printers/common.ts
@@ -135,14 +135,24 @@ export const methodSignature = (
   return `${left}${isMethod ? "" : ": "}${right}`;
 };
 
-export const generics = (
+export const generics = (types?: ReadonlyArray<RawNode> | null): string => {
+  if (types && typeof types.length !== "undefined") {
+    return `<${types.map(printers.node.printType).join(", ")}>`;
+  }
+  return "";
+};
+
+export const genericsWithoutDefault = (
   types?: ReadonlyArray<RawNode> | null,
-  map: (node: RawNode) => RawNode = node => node,
 ): string => {
   if (types && typeof types.length !== "undefined") {
-    return `<${types.map(map).map(printers.node.printType).join(", ")}>`;
+    return `<${types
+      .map(node => {
+        node.withoutDefault = true;
+        return printers.node.printType(node);
+      })
+      .join(", ")}>`;
   }
-
   return "";
 };
 

--- a/src/printers/common.ts
+++ b/src/printers/common.ts
@@ -38,7 +38,13 @@ export const typeParameter = (
   return `${node.name.text}${constraint}${defaultType}`;
 };
 
-export const parameter = (param: RawNode): string => {
+export const parameter = (
+  param:
+    | ts.ParameterDeclaration
+    | ts.PropertySignature
+    | ts.GetAccessorDeclaration
+    | ts.SetAccessorDeclaration,
+): string => {
   let left = "";
   if (param.modifiers) {
     for (const modifier of param.modifiers) {
@@ -48,7 +54,7 @@ export const parameter = (param: RawNode): string => {
   if (param.kind === ts.SyntaxKind.SetAccessor) {
     left += "-";
   }
-  let right;
+  let right: string;
 
   if (
     param.name.kind === ts.SyntaxKind.ObjectBindingPattern ||
@@ -89,7 +95,7 @@ export const parameter = (param: RawNode): string => {
     right = `(${right}) | void`;
   }
 
-  if (param.dotDotDotToken) {
+  if (ts.isParameter(param) && param.dotDotDotToken) {
     left = "..." + left;
   }
 

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -8,13 +8,12 @@ import * as printers from "./index";
 import { withEnv } from "../env";
 
 export const propertyDeclaration = (
-  node: RawNode,
+  node: ts.VariableDeclaration | ts.PropertyDeclaration,
   keywordPrefix: string,
-  isVar = false,
 ): string => {
   let left = keywordPrefix;
   const symbol = checker.current.getSymbolAtLocation(node.name);
-  const name = isVar
+  const name = ts.isVariableDeclaration(node)
     ? printers.node.getFullyQualifiedName(symbol, node.name)
     : printers.node.printType(node.name);
   if (
@@ -36,23 +35,14 @@ export const propertyDeclaration = (
 
   left += name;
 
-  if (node.parameters) {
-    return left + ": " + node.parameters.map(printers.common.parameter);
-  }
-
   if (node.type) {
     let right = printers.node.printType(node.type);
-    if (
-      node.questionToken &&
-      node.name.kind !== ts.SyntaxKind.ComputedPropertyName
-    ) {
-      left += "?";
-    }
-    if (
-      node.questionToken &&
-      node.name.kind === ts.SyntaxKind.ComputedPropertyName
-    ) {
-      right = `(${right}) | void`;
+    if (ts.isPropertyDeclaration(node) && node.questionToken) {
+      if (node.name.kind !== ts.SyntaxKind.ComputedPropertyName) {
+        left += "?";
+      } else {
+        right = `(${right}) | void`;
+      }
     }
     return left + ": " + right;
   }

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -166,7 +166,6 @@ const interfaceHeritageClause = type => {
   } else if (type.expression.kind === ts.SyntaxKind.Identifier) {
     const name = printers.identifiers.print(type.expression.text);
     if (typeof name === "function") {
-      // @ts-expect-error todo(flow->ts)
       return name(type.typeArguments);
     } else {
       return name;

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -152,17 +152,17 @@ const classHeritageClause = withEnv<
   return ret;
 });
 
-const interfaceHeritageClause = type => {
+const interfaceHeritageClause = (type: ts.ExpressionWithTypeArguments) => {
   // TODO: refactor this
   const symbol = checker.current.getSymbolAtLocation(type.expression);
   printers.node.fixDefaultTypeArguments(symbol, type);
-  if (type.expression.kind === ts.SyntaxKind.Identifier && symbol) {
+  if (ts.isIdentifier(type.expression) && symbol) {
     const name = printers.node.getFullyQualifiedPropertyAccessExpression(
       symbol,
       type.expression,
     );
     return name + printers.common.generics(type.typeArguments);
-  } else if (type.expression.kind === ts.SyntaxKind.Identifier) {
+  } else if (ts.isIdentifier(type.expression)) {
     const name = printers.identifiers.print(type.expression.text);
     if (typeof name === "function") {
       return name(type.typeArguments);

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -70,18 +70,10 @@ export const interfaceType = <T>(
   const isInexact = opts().inexact;
   const members = node.members.map(member => {
     const printed = printers.node.printType(member);
-
     if (!printed) {
       return null;
     }
-
-    let str = "\n";
-
-    if (member.jsDoc) {
-      str += printers.common.comment(member.jsDoc);
-    }
-
-    return str + printed;
+    return "\n" + printers.common.jsdoc(member) + printed;
   });
 
   if (mergedNamespaceChildren.length > 0) {
@@ -119,18 +111,10 @@ const interfaceRecordType = (
   let members = node.members
     .map(member => {
       const printed = printers.node.printType(member);
-
       if (!printed) {
         return null;
       }
-
-      let str = "\n";
-
-      if (member.jsDoc) {
-        str += printers.common.comment(member.jsDoc);
-      }
-
-      return str + printed;
+      return "\n" + printers.common.jsdoc(member) + printed;
     })
     .filter(Boolean) // Filter rows which didnt print propely (private fields et al)
     .join(withSemicolons ? ";" : ",");

--- a/src/printers/function.ts
+++ b/src/printers/function.ts
@@ -2,9 +2,19 @@ import * as ts from "typescript";
 import type { RawNode } from "../nodes/node";
 import * as printers from "./index";
 
-export const functionType = (func: RawNode, dotAsReturn = false): string => {
+export const functionType = (
+  func:
+    | ts.FunctionTypeNode
+    | ts.FunctionDeclaration
+    | ts.MethodDeclaration
+    | ts.MethodSignature
+    | ts.ConstructSignatureDeclaration,
+  dotAsReturn = false,
+): string => {
   const params = func.parameters
-    .filter(param => param.name.text !== "this")
+    .filter(
+      param => !(ts.isIdentifier(param.name) && param.name.text === "this"),
+    )
     .map(printers.common.parameter);
   const generics = printers.common.genericsWithoutDefault(func.typeParameters);
   const returns = func.type ? printers.node.printType(func.type) : "void";

--- a/src/printers/function.ts
+++ b/src/printers/function.ts
@@ -6,10 +6,7 @@ export const functionType = (func: RawNode, dotAsReturn = false): string => {
   const params = func.parameters
     .filter(param => param.name.text !== "this")
     .map(printers.common.parameter);
-  const generics = printers.common.generics(func.typeParameters, node => {
-    node.withoutDefault = true;
-    return node;
-  });
+  const generics = printers.common.genericsWithoutDefault(func.typeParameters);
   const returns = func.type ? printers.node.printType(func.type) : "void";
 
   const firstPass = `${generics}(${params.join(", ")})${

--- a/src/printers/identifiers.ts
+++ b/src/printers/identifiers.ts
@@ -29,8 +29,9 @@ const Record = ([key, value]: [any, any], isInexact = opts().inexact) => {
   }
 };
 
-const identifiers = Object.create(null);
-Object.assign(identifiers, {
+type IdentifierResult = string | ((...args: any[]) => any);
+
+const identifiers: { [name: string]: IdentifierResult } = {
   ReadonlyArray: "$ReadOnlyArray",
   ReadonlySet: "$ReadOnlySet",
   ReadonlyMap: "$ReadOnlyMap",
@@ -55,11 +56,11 @@ Object.assign(identifiers, {
       false,
     )}>`;
   },
-});
+};
 
-export const print = withEnv<any, [string], string>(
-  (env, kind: string): string => {
-    if (env.classHeritage) return kind;
-    return identifiers[kind] || kind;
-  },
-);
+export const print = withEnv<any, [string], IdentifierResult>((env, kind) => {
+  if (env.classHeritage) return kind;
+  return Object.prototype.hasOwnProperty.call(identifiers, kind)
+    ? identifiers[kind]
+    : kind;
+});

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -108,6 +108,7 @@ export function printPropertyAccessExpression(
     );
   } else if (type.kind === ts.SyntaxKind.Identifier) {
     return printers.relationships.namespace(
+      // @ts-expect-error todo(flow->ts)
       printers.identifiers.print(type.text),
       true,
     );
@@ -504,6 +505,7 @@ export const printType = withEnv<any, [any], string>(
       //case SyntaxKind.StringLiteralType:
       case ts.SyntaxKind.Identifier: {
         return printers.relationships.namespace(
+          // @ts-expect-error todo(flow->ts)
           printers.identifiers.print(type.text),
           true,
         );

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -673,11 +673,8 @@ export const printType = withEnv<any, [any], string>(
       }
 
       case ts.SyntaxKind.VariableDeclaration:
-        return printers.declarations.propertyDeclaration(
-          type,
-          keywordPrefix,
-          true,
-        );
+        return printers.declarations.propertyDeclaration(type, keywordPrefix);
+
       case ts.SyntaxKind.PropertyDeclaration:
         return printers.declarations.propertyDeclaration(type, keywordPrefix);
 

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -723,10 +723,9 @@ export const printType = withEnv<any, [any], string>(
 
       case ts.SyntaxKind.CallSignature: {
         // TODO: rewrite to printers.functions.functionType
-        const generics = printers.common.generics(type.typeParameters, node => {
-          node.withoutDefault = true;
-          return node;
-        });
+        const generics = printers.common.genericsWithoutDefault(
+          type.typeParameters,
+        );
         const str = `${generics}(${type.parameters
           // @ts-expect-error todo(flow->ts)
           .filter(param => param.name.text !== "this")


### PR DESCRIPTION
This is another round of adding real, non-`any`, type annotations, like #181.

These are focused on some code I was working on bugfixes for today. Those bugfixes themselves aren't yet ready, but in the meantime this part seems independently helpful so I figured I'd share it.
