### PR TITLE
Fix issue where transformers didn't run on imported files

### DIFF
--- a/src/__tests__/__snapshots__/import.spec.ts.snap
+++ b/src/__tests__/__snapshots__/import.spec.ts.snap
@@ -10,6 +10,17 @@ declare type D = $Flowgen$Import$zlib.Zlib;
 "
 `;
 
+exports[`should handle import in an imported file: src/__tests__/snippet/import-import-type.ts 1`] = `
+"declare export { R } from \\"./import-type\\";
+"
+`;
+
+exports[`should handle import in an imported file: src/__tests__/snippet/import-type.ts 1`] = `
+"import * as $Flowgen$Import$react from \\"react\\";
+declare export var R: $Flowgen$Import$react.RefAttributes<any>;
+"
+`;
+
 exports[`should handle import nested in type arguments of import 1`] = `
 "import * as $Flowgen$Import$react from \\"react\\";
 declare type A = $Flowgen$Import$react.ComponentType<

--- a/src/__tests__/import.spec.ts
+++ b/src/__tests__/import.spec.ts
@@ -40,3 +40,19 @@ type A = import("react").ComponentType<import("react").ComponentType<any>>;
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle import in an imported file", () => {
+  // There once was a bug where transformers wouldn't get run on the second
+  // (or later) file in a list like this.  Test that the transformer
+  // implementing this feature does indeed run there.
+  const results = compiler.compileDefinitionFiles(
+    [
+      "src/__tests__/snippet/import-import-type.ts",
+      "src/__tests__/snippet/import-type.ts",
+    ],
+    { quiet: false },
+  );
+  for (const result of results) {
+    expect(beautify(result[1])).toMatchSnapshot(result[0]);
+  }
+});

--- a/src/__tests__/snippet/import-import-type.ts
+++ b/src/__tests__/snippet/import-import-type.ts
@@ -1,0 +1,1 @@
+export { R } from "./import-type";

--- a/src/__tests__/snippet/import-type.ts
+++ b/src/__tests__/snippet/import-type.ts
@@ -1,0 +1,1 @@
+export declare const R: import("react").RefAttributes<any>;

--- a/src/cli/compiler.ts
+++ b/src/cli/compiler.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import ts, {
   createProgram,
   createCompilerHost,
@@ -135,8 +136,9 @@ export default {
     const oldReadFile = compilerHost.readFile;
     compilerHost.readFile = fileName =>
       mapSourceCode(oldReadFile(fileName), fileName);
+    const absolutePath = path.resolve(definitionPath);
     compilerHost.getSourceFile = (file, languageVersion) => {
-      if (file === definitionPath) {
+      if (path.resolve(file) === absolutePath) {
         const sourceText = compilerHost.readFile(file);
         return transformFile(file, sourceText, languageVersion, options);
       }
@@ -172,8 +174,9 @@ export default {
     const oldReadFile = compilerHost.readFile;
     compilerHost.readFile = fileName =>
       mapSourceCode(oldReadFile(fileName), fileName);
+    const absolutePaths = new Set(definitionPaths.map(p => path.resolve(p)));
     compilerHost.getSourceFile = (file, languageVersion) => {
-      if (definitionPaths.includes(file)) {
+      if (absolutePaths.has(path.resolve(file))) {
         const sourceText = compilerHost.readFile(file);
         return transformFile(file, sourceText, languageVersion, options);
       }

--- a/src/cli/compiler.ts
+++ b/src/cli/compiler.ts
@@ -92,8 +92,8 @@ export default {
     return getTransformers(options);
   },
 
-  compileTest: (path: string, target: string): void => {
-    tsc.compile(path, "--module commonjs -t ES6 --out " + target);
+  compileTest: (testPath: string, target: string): void => {
+    tsc.compile(testPath, "--module commonjs -t ES6 --out " + target);
   },
 
   compileDefinitionString: (string: string, options?: Options): string => {
@@ -121,7 +121,7 @@ export default {
   },
 
   compileDefinitionFile: (
-    path: string,
+    definitionPath: string,
     options?: Options,
     mapSourceCode: (
       source: string | undefined,
@@ -136,17 +136,21 @@ export default {
     compilerHost.readFile = fileName =>
       mapSourceCode(oldReadFile(fileName), fileName);
     compilerHost.getSourceFile = (file, languageVersion) => {
-      if (file === path) {
+      if (file === definitionPath) {
         const sourceText = compilerHost.readFile(file);
         return transformFile(file, sourceText, languageVersion, options);
       }
       return oldSourceFile(file, languageVersion);
     };
 
-    const program = createProgram([path], compilerOptions, compilerHost);
+    const program = createProgram(
+      [definitionPath],
+      compilerOptions,
+      compilerHost,
+    );
 
     checker.current = program.getTypeChecker();
-    const sourceFile = program.getSourceFile(path);
+    const sourceFile = program.getSourceFile(definitionPath);
 
     if (!sourceFile) return "";
 
@@ -156,7 +160,7 @@ export default {
   },
 
   compileDefinitionFiles: (
-    paths: string[],
+    definitionPaths: string[],
     options?: Options,
     mapSourceCode: (
       source: string | undefined,
@@ -169,23 +173,27 @@ export default {
     compilerHost.readFile = fileName =>
       mapSourceCode(oldReadFile(fileName), fileName);
     compilerHost.getSourceFile = (file, languageVersion) => {
-      if (paths.includes(file)) {
+      if (definitionPaths.includes(file)) {
         const sourceText = compilerHost.readFile(file);
         return transformFile(file, sourceText, languageVersion, options);
       }
       return oldSourceFile(file, languageVersion);
     };
 
-    const program = createProgram(paths, compilerOptions, compilerHost);
+    const program = createProgram(
+      definitionPaths,
+      compilerOptions,
+      compilerHost,
+    );
 
     checker.current = program.getTypeChecker();
 
-    return paths.map(path => {
-      const sourceFile = program.getSourceFile(path);
-      if (!sourceFile) return [path, ""];
+    return definitionPaths.map(definitionPath => {
+      const sourceFile = program.getSourceFile(definitionPath);
+      if (!sourceFile) return [definitionPath, ""];
       logger.setSourceFile(sourceFile);
       reset(options);
-      return [path, compile.withEnv({})(sourceFile)];
+      return [definitionPath, compile.withEnv({})(sourceFile)];
     });
   },
 };


### PR DESCRIPTION
The `file` parameter TS passes to `compilerHost.getSourceFile` will
sometimes be the same path string that we passed to `createProgram`.
In particular, it seems to work that way for the very first file in
the list.

But then if that file imports from other files, the TS compiler will
go find those files and pass them to `getSourceFile` using absolute
paths, even if the same file appears in our list under a relative
path.

As a result, when comparing the filename passed to `getSourceFile`
against our list of files we mean to operate on, we'll miss that it's
there and fail to realize we should apply our transformers.

Fix the issue by making those comparisons entirely in terms of
absolute paths.  Also, while we're here, use a Set instead of
searching through an Array, so that the lookups take O(1) time.

And add a test that reproduces the issue.
