### PR TITLE
Fix a class of bugs with exact vs. inexact object types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,11 +1,4 @@
-[ignore]
-
-[include]
-
-[libs]
-
 [lints]
-
-[options]
-
-[strict]
+; This Flow config is used when having Flow check our output for validity,
+; in test cases that use `expect(…).toBeValidFlowTypeDeclarations()`.
+implicit-inexact-object=error

--- a/src/__tests__/__snapshots__/classes.spec.ts.snap
+++ b/src/__tests__/__snapshots__/classes.spec.ts.snap
@@ -17,10 +17,7 @@ declare class Observable<T> mixins Subscribable<T> {
   jump?: () => void;
   +jump?: () => void;
   static +jump?: () => void;
-  cfnProperties: {
-    [key: string]: any,
-    ...
-  };
+  cfnProperties: { [key: string]: any, ... };
   static fooGet: string;
 }
 "

--- a/src/__tests__/__snapshots__/duplicated-names.spec.ts.snap
+++ b/src/__tests__/__snapshots__/duplicated-names.spec.ts.snap
@@ -34,10 +34,7 @@ export type AuthMechanismType = $ElementType<
 `;
 
 exports[`should support generic type rename 1`] = `
-"declare export var ProfilingLevel: $ReadOnly<{
-  +off: \\"off\\",
-  ...
-}>;
+"declare export var ProfilingLevel: $ReadOnly<{ +off: \\"off\\", ... }>;
 export type ProfilingLevelType = $ElementType<
   typeof ProfilingLevel,
   $Keys<typeof ProfilingLevel>

--- a/src/__tests__/__snapshots__/enums.spec.ts.snap
+++ b/src/__tests__/__snapshots__/enums.spec.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`should handle basic enums: class 1`] = `
 "declare var Label: {|
-  +LABEL_OPTIONAL: 0, // 0
-  +LABEL_REQUIRED: 1, // 1
-  +LABEL_REPEATED: 2, // 2
+  +LABEL_OPTIONAL: 0,
+  +LABEL_REQUIRED: 1,
+  +LABEL_REPEATED: 2,
 |};
 declare type A = $Values<typeof Label>;
 declare type B = typeof Label.LABEL_OPTIONAL;
@@ -18,8 +18,8 @@ exports[`should handle empty enums: class 1`] = `
 
 exports[`should handle importing enum types: class 1`] = `
 "declare export var Label: {|
-  +A: \\"A\\", // \\"A\\"
-  +B: \\"B\\", // \\"B\\"
+  +A: \\"A\\",
+  +B: \\"B\\",
 |};
 "
 `;
@@ -32,8 +32,8 @@ declare export function foo(label: $Values<Label>): void;
 
 exports[`should handle importing enums: class 1`] = `
 "declare export var Label: {|
-  +A: \\"A\\", // \\"A\\"
-  +B: \\"B\\", // \\"B\\"
+  +A: \\"A\\",
+  +B: \\"B\\",
 |};
 "
 `;
@@ -46,11 +46,11 @@ declare export function foo(label: $Values<typeof Label>): void;
 
 exports[`should handle number enums: class 1`] = `
 "declare var Label: {|
-  +ONE: 1, // 1
-  +TWO: 2, // 2
-  +THREE: 3, // 3
-  +NEGATIVE: -123, // -123
-  +DECIMAL: 3.14, // 3.14
+  +ONE: 1,
+  +TWO: 2,
+  +THREE: 3,
+  +NEGATIVE: -123,
+  +DECIMAL: 3.14,
 |};
 declare type A = $Values<typeof Label>;
 declare type B = typeof Label.TWO;
@@ -59,9 +59,9 @@ declare type B = typeof Label.TWO;
 
 exports[`should handle string enums: class 1`] = `
 "declare var Label: {|
-  +LABEL_OPTIONAL: \\"LABEL_OPTIONAL\\", // \\"LABEL_OPTIONAL\\"
-  +LABEL_REQUIRED: \\"LABEL_REQUIRED\\", // \\"LABEL_REQUIRED\\"
-  +LABEL_REPEATED: \\"LABEL_REPEATED\\", // \\"LABEL_REPEATED\\"
+  +LABEL_OPTIONAL: \\"LABEL_OPTIONAL\\",
+  +LABEL_REQUIRED: \\"LABEL_REQUIRED\\",
+  +LABEL_REPEATED: \\"LABEL_REPEATED\\",
 |};
 declare type A = $Values<typeof Label>;
 declare type B = typeof Label.LABEL_REQUIRED;

--- a/src/__tests__/__snapshots__/interfaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.ts.snap
@@ -14,10 +14,7 @@ exports[`should handle interface inheritance 1`] = `
 "declare interface User {
   firstName: string;
 }
-declare type SpecialUser = {
-  nice: number,
-  ...
-} & User;
+declare type SpecialUser = { nice: number, ... } & User;
 "
 `;
 
@@ -42,6 +39,14 @@ declare type SpecialUser = {|
 
   nice: number,
 |};
+"
+`;
+
+exports[`should handle interface inheritance 4`] = `
+"declare interface User {
+  firstName: string;
+}
+declare type SpecialUser = { nice: number, ... } & User;
 "
 `;
 
@@ -70,11 +75,7 @@ exports[`should handle mutli-extends pattern 1`] = `
 declare interface PenStroke {
   penWidth: number;
 }
-declare type Square = {
-  sideLength: number,
-  ...
-} & Shape &
-  PenStroke;
+declare type Square = { sideLength: number, ... } & Shape & PenStroke;
 "
 `;
 

--- a/src/__tests__/__snapshots__/interfaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.ts.snap
@@ -19,24 +19,19 @@ declare type SpecialUser = { nice: number, ... } & User;
 `;
 
 exports[`should handle interface inheritance 2`] = `
-"declare type User = {
-  firstName: string,
-};
+"declare type User = { firstName: string, ... };
 declare type SpecialUser = {
   ...$Exact<User>,
-
   nice: number,
+  ...
 };
 "
 `;
 
 exports[`should handle interface inheritance 3`] = `
-"declare type User = {|
-  firstName: string,
-|};
+"declare type User = {| firstName: string |};
 declare type SpecialUser = {|
   ...$Exact<User>,
-
   nice: number,
 |};
 "
@@ -64,6 +59,7 @@ exports[`should handle interface merging 2`] = `
   firstName: string,
   lastName: string,
   username: string,
+  ...
 };
 "
 `;
@@ -87,9 +83,7 @@ exports[`should handle single interface 1`] = `
 `;
 
 exports[`should handle single interface 2`] = `
-"declare type User = {
-  firstName: string,
-};
+"declare type User = { firstName: string, ... };
 "
 `;
 

--- a/src/__tests__/__snapshots__/interfaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.ts.snap
@@ -133,8 +133,12 @@ exports[`should handle untyped array binding pattern 1`] = `
 exports[`should handle untyped object binding pattern 1`] = `
 "declare interface ObjectBinding {
   (): void;
-  (x: {}): void;
-  (x: { a: any, b: any }): void;
+  (x: { ... }): void;
+  (x: {
+    a: any,
+    b: any,
+    ...
+  }): void;
 }
 "
 `;

--- a/src/__tests__/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/mapped-types.spec.ts.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle mapped types 1`] = `
-"declare type Ref<T> = {
-  current: T | null,
-  ...
-};
+"declare type Ref<T> = { current: T | null, ... };
 declare type SourceUnion = \\"a\\" | \\"b\\" | \\"c\\";
 declare type SourceObject = {
   a: number,

--- a/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
@@ -3,10 +3,7 @@
 exports[`should handle global types jsx 1`] = `
 "import * as React from \\"react\\";
 declare function s(node: React$Node): void;
-declare type Props = {
-  children: React$Node,
-  ...
-};
+declare type Props = { children: React$Node, ... };
 declare class Component mixins React.Component<Props> {
   render(): React$Node;
 }

--- a/src/__tests__/__snapshots__/modules.spec.ts.snap
+++ b/src/__tests__/__snapshots__/modules.spec.ts.snap
@@ -10,14 +10,8 @@ exports[`should handle module 1`] = `
         value: T,
         ...
       }
-    | {
-        type: \\"nothing\\",
-        ...
-      };
-  declare export type Ref<T> = {
-    current: T,
-    ...
-  };
+    | { type: \\"nothing\\", ... };
+  declare export type Ref<T> = { current: T, ... };
   declare export var ok: number;
 }
 "

--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -194,9 +194,7 @@ declare interface E0$U1$S3 {
 
 declare var E0$U1$e2: number;
 
-declare var E0$U1$E2: {|
-  +E: 1,
-|};
+declare var E0$U1$E2: {| +E: 1 |};
 
 declare var npm$namespace$E0$U1$D1: {| S2: typeof npm$namespace$E0$U1$D1$S2 |};
 

--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -35,9 +35,7 @@ exports[`should handle merging with other types enum 1`] = `
 |};
 declare var Color: typeof npm$namespace$Color;
 
-declare var npm$namespace$Color: {|
-  mixColor: typeof Color$mixColor,
-|};
+declare var npm$namespace$Color: {| mixColor: typeof Color$mixColor |};
 declare export function Color$mixColor(colorName: string): number;
 "
 `;
@@ -69,9 +67,7 @@ export interface test$Foo {
 exports[`should handle merging with other types function type 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {|
-  (foo: number): string,
-|};
+declare var npm$namespace$test: {| (foo: number): string |};
 export type test$Foo = {
   bar: number,
   ...
@@ -82,9 +78,7 @@ export type test$Foo = {
 exports[`should handle namespace function merging 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {|
-  test: typeof test$test,
-|};
+declare var npm$namespace$test: {| test: typeof test$test |};
 declare function test$test(err: number): void;
 
 declare function test$test(response: string): string;
@@ -107,9 +101,7 @@ declare export var test$error: string;
 exports[`should handle namespaces 1`] = `
 "declare var test: typeof npm$namespace$test;
 
-declare var npm$namespace$test: {|
-  ok: typeof test$ok,
-|};
+declare var npm$namespace$test: {| ok: typeof test$ok |};
 declare export var test$ok: number;
 "
 `;
@@ -117,9 +109,7 @@ declare export var test$ok: number;
 exports[`should handle nested namespace merging class 1`] = `
 "declare var ns: typeof npm$namespace$ns;
 
-declare var npm$namespace$ns: {|
-  Album: typeof ns$Album,
-|};
+declare var npm$namespace$ns: {| Album: typeof ns$Album |};
 declare class ns$Album {
   label: ns$Album.AlbumLabel;
   static AlbumLabel: typeof ns$Album$AlbumLabel;
@@ -132,9 +122,7 @@ declare export class ns$Album$AlbumLabel {}
 exports[`should handle nested namespace merging enum 1`] = `
 "declare var ns: typeof npm$namespace$ns;
 
-declare var npm$namespace$ns: {|
-  Color: typeof npm$namespace$ns$Color,
-|};
+declare var npm$namespace$ns: {| Color: typeof npm$namespace$ns$Color |};
 
 declare var ns$Color: {|
   +red: 1, // 1
@@ -142,9 +130,7 @@ declare var ns$Color: {|
   +blue: 4, // 4
 |};
 
-declare var npm$namespace$ns$Color: {|
-  mixColor: typeof ns$Color$mixColor,
-|};
+declare var npm$namespace$ns$Color: {| mixColor: typeof ns$Color$mixColor |};
 declare export function ns$Color$mixColor(colorName: string): number;
 "
 `;
@@ -152,9 +138,7 @@ declare export function ns$Color$mixColor(colorName: string): number;
 exports[`should handle nested namespace merging function const 1`] = `
 "declare var ns: typeof npm$namespace$ns;
 
-declare var npm$namespace$ns: {|
-  test: typeof npm$namespace$ns$test,
-|};
+declare var npm$namespace$ns: {| test: typeof npm$namespace$ns$test |};
 
 declare var npm$namespace$ns$test: {|
   (foo: number): string,
@@ -167,9 +151,7 @@ declare export var test$ok: number;
 exports[`should handle nested namespace merging function interface 1`] = `
 "declare var ns: typeof npm$namespace$ns;
 
-declare var npm$namespace$ns: {|
-  test: typeof ns$test,
-|};
+declare var npm$namespace$ns: {| test: typeof ns$test |};
 
 declare var npm$namespace$ns$test: {|
   (foo: number): string,
@@ -184,13 +166,9 @@ export interface ns$test$Foo {
 exports[`should handle nested namespace merging function type 1`] = `
 "declare var ns: typeof npm$namespace$ns;
 
-declare var npm$namespace$ns: {|
-  test: typeof ns$test,
-|};
+declare var npm$namespace$ns: {| test: typeof ns$test |};
 
-declare var npm$namespace$ns$test: {|
-  (foo: number): string,
-|};
+declare var npm$namespace$ns$test: {| (foo: number): string |};
 export type ns$test$Foo = {
   bar: number,
   ...
@@ -226,9 +204,7 @@ declare var E0$U1$E2: {|
   +E: 1, // 1
 |};
 
-declare var npm$namespace$E0$U1$D1: {|
-  S2: typeof npm$namespace$E0$U1$D1$S2,
-|};
+declare var npm$namespace$E0$U1$D1: {| S2: typeof npm$namespace$E0$U1$D1$S2 |};
 
 declare var npm$namespace$E0$U1$D1$S2: {|
   n3: typeof E0$U1$D1$S2$n3,
@@ -243,16 +219,12 @@ declare var E0$U1$D1$S2$n3: Symbol;
 
 declare class E0$U1$D1$S2$N3 {}
 
-declare var npm$namespace$E0$U1$DD1$S2: {|
-  S3: Class<E0$U1$DD1$S2$S3>,
-|};
+declare var npm$namespace$E0$U1$DD1$S2: {| S3: Class<E0$U1$DD1$S2$S3> |};
 declare interface E0$U1$DD1$S2$S3 {
   e: number;
 }
 
-declare var npm$namespace$E0$S1: {|
-  m3: typeof E0$S1$m3,
-|};
+declare var npm$namespace$E0$S1: {| m3: typeof E0$S1$m3 |};
 declare var E0$S1$m3: string;
 
 declare var E0$s1: string;
@@ -262,9 +234,7 @@ declare var E0$s1: string;
 exports[`should handle qualified namespaces 1`] = `
 "declare var A: typeof npm$namespace$A;
 
-declare var npm$namespace$A: {|
-  B: typeof npm$namespace$A$B,
-|};
+declare var npm$namespace$A: {| B: typeof npm$namespace$A$B |};
 
 declare var npm$namespace$A$B: {|
   D: typeof A$B$D,
@@ -277,9 +247,7 @@ declare interface A$B$S<A> {
 
 declare class A$B$D<S> {}
 
-declare var npm$namespace$A$B$C: {|
-  N: typeof A$B$C$N,
-|};
+declare var npm$namespace$A$B$C: {| N: typeof A$B$C$N |};
 declare class A$B$C$N<A> mixins A$B$D<A>, A$B$S<A> {
   a: string;
 }

--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -68,10 +68,7 @@ exports[`should handle merging with other types function type 1`] = `
 "declare var test: typeof npm$namespace$test;
 
 declare var npm$namespace$test: {| (foo: number): string |};
-export type test$Foo = {
-  bar: number,
-  ...
-};
+export type test$Foo = { bar: number, ... };
 "
 `;
 
@@ -169,10 +166,7 @@ exports[`should handle nested namespace merging function type 1`] = `
 declare var npm$namespace$ns: {| test: typeof ns$test |};
 
 declare var npm$namespace$ns$test: {| (foo: number): string |};
-export type ns$test$Foo = {
-  bar: number,
-  ...
-};
+export type ns$test$Foo = { bar: number, ... };
 "
 `;
 

--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -29,9 +29,9 @@ declare export class Album$AlbumLabel {}
 
 exports[`should handle merging with other types enum 1`] = `
 "declare var Color: {|
-  +red: 1, // 1
-  +green: 2, // 2
-  +blue: 4, // 4
+  +red: 1,
+  +green: 2,
+  +blue: 4,
 |};
 declare var Color: typeof npm$namespace$Color;
 
@@ -122,9 +122,9 @@ exports[`should handle nested namespace merging enum 1`] = `
 declare var npm$namespace$ns: {| Color: typeof npm$namespace$ns$Color |};
 
 declare var ns$Color: {|
-  +red: 1, // 1
-  +green: 2, // 2
-  +blue: 4, // 4
+  +red: 1,
+  +green: 2,
+  +blue: 4,
 |};
 
 declare var npm$namespace$ns$Color: {| mixColor: typeof ns$Color$mixColor |};
@@ -195,7 +195,7 @@ declare interface E0$U1$S3 {
 declare var E0$U1$e2: number;
 
 declare var E0$U1$E2: {|
-  +E: 1, // 1
+  +E: 1,
 |};
 
 declare var npm$namespace$E0$U1$D1: {| S2: typeof npm$namespace$E0$U1$D1$S2 |};

--- a/src/__tests__/__snapshots__/spread.spec.ts.snap
+++ b/src/__tests__/__snapshots__/spread.spec.ts.snap
@@ -16,7 +16,11 @@ declare type Bar = {
   bar: string,
   ...
 };
-declare var combination: { ...Foo, ...Bar };
+declare var combination: {
+  ...Foo,
+  ...Bar,
+  ...
+};
 "
 `;
 
@@ -27,6 +31,9 @@ exports[`should use spread when performing union of object types 2`] = `
 declare type Bar = {|
   bar: string,
 |};
-declare var combination: {| ...Foo, ...Bar |};
+declare var combination: {|
+  ...Foo,
+  ...Bar,
+|};
 "
 `;

--- a/src/__tests__/__snapshots__/spread.spec.ts.snap
+++ b/src/__tests__/__snapshots__/spread.spec.ts.snap
@@ -8,14 +8,8 @@ declare var combination: Foo & Bar;
 `;
 
 exports[`should use spread when performing union of object types 1`] = `
-"declare type Foo = {
-  foo: number,
-  ...
-};
-declare type Bar = {
-  bar: string,
-  ...
-};
+"declare type Foo = { foo: number, ... };
+declare type Bar = { bar: string, ... };
 declare var combination: {
   ...Foo,
   ...Bar,
@@ -25,12 +19,8 @@ declare var combination: {
 `;
 
 exports[`should use spread when performing union of object types 2`] = `
-"declare type Foo = {|
-  foo: number,
-|};
-declare type Bar = {|
-  bar: string,
-|};
+"declare type Foo = {| foo: number |};
+declare type Bar = {| bar: string |};
 declare var combination: {|
   ...Foo,
   ...Bar,

--- a/src/__tests__/__snapshots__/string-literals.spec.ts.snap
+++ b/src/__tests__/__snapshots__/string-literals.spec.ts.snap
@@ -12,33 +12,15 @@ exports[`should handle string literals in function argument "overloading" 1`] = 
   on(event: \\"close\\", cb: (code: number, message: string) => void): void;
   on(
     event: \\"message\\",
-    cb: (
-      data: any,
-      flags: {
-        binary: boolean,
-        ...
-      }
-    ) => void
+    cb: (data: any, flags: { binary: boolean, ... }) => void
   ): void;
   on(
     event: \\"ping\\",
-    cb: (
-      data: any,
-      flags: {
-        binary: boolean,
-        ...
-      }
-    ) => void
+    cb: (data: any, flags: { binary: boolean, ... }) => void
   ): void;
   on(
     event: \\"pong\\",
-    cb: (
-      data: any,
-      flags: {
-        binary: boolean,
-        ...
-      }
-    ) => void
+    cb: (data: any, flags: { binary: boolean, ... }) => void
   ): void;
   on(event: \\"open\\", cb: () => void): void;
   on(event: string, listener: (...args: any[]) => void): void;

--- a/src/__tests__/__snapshots__/type-exports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/type-exports.spec.ts.snap
@@ -1,15 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle export list syntax 1`] = `
-"declare type ComplexType =
-  | {
-      type: number,
-      ...
-    }
-  | {
-      type: string,
-      ...
-    };
+"declare type ComplexType = { type: number, ... } | { type: string, ... };
 export type { ComplexType };
 declare var foo: 5;
 declare export { foo };
@@ -24,23 +16,12 @@ export type Maybe<T> =
       value: T,
       ...
     }
-  | {
-      type: \\"nothing\\",
-      ...
-    };
+  | { type: \\"nothing\\", ... };
 "
 `;
 
 exports[`should handle inline export list syntax 1`] = `
-"declare type ComplexType =
-  | {
-      type: number,
-      ...
-    }
-  | {
-      type: string,
-      ...
-    };
+"declare type ComplexType = { type: number, ... } | { type: string, ... };
 declare var foo: 5;
 export type { ComplexType };
 declare export { foo };

--- a/src/__tests__/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.ts.snap
@@ -71,7 +71,7 @@ declare type B = $Rest<
   {|
     a: number,
   |},
-  {}
+  { ... }
 >;
 declare type C = $NonMaybeType<string | null>;
 declare type D = $ReadOnlyArray<string>;
@@ -86,7 +86,7 @@ declare type D1<ReadonlyArray> = ReadonlyArray;
 declare type E1<ReturnType> = ReturnType;
 declare type F1<Record> = Record;
 declare type A2<T> = $ReadOnly<T>;
-declare type B2<T> = $Rest<T, {}>;
+declare type B2<T> = $Rest<T, { ... }>;
 declare type C2<T> = $NonMaybeType<T>;
 declare type D2<T> = $ReadOnlyArray<T>;
 declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;

--- a/src/__tests__/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`should handle Omit type 1`] = `
     b: number,
     ...
   },
-  { a: any }
+  {| a: any |}
 >;
 declare type B = $Diff<
   {
@@ -15,7 +15,10 @@ declare type B = $Diff<
     b: number,
     ...
   },
-  { a: any, b: any }
+  {|
+    a: any,
+    b: any,
+  |}
 >;
 declare type O = {
   a: string,
@@ -23,7 +26,7 @@ declare type O = {
   ...
 };
 declare type U = \\"a\\";
-declare type C = $Diff<O, { [key: U]: any }>;
+declare type C = $Diff<O, {| [key: U]: any |}>;
 "
 `;
 

--- a/src/__tests__/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.ts.snap
@@ -62,3 +62,34 @@ declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
 declare type F2<T, U> = { [key: T]: U, ... };
 "
 `;
+
+exports[`should handle utility types 2`] = `
+"declare type A = $ReadOnly<{|
+  a: number,
+|}>;
+declare type B = $Rest<
+  {|
+    a: number,
+  |},
+  {}
+>;
+declare type C = $NonMaybeType<string | null>;
+declare type D = $ReadOnlyArray<string>;
+declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;
+declare type F = {| [key: string]: number |};
+declare type G = $ReadOnlySet<number>;
+declare type H = $ReadOnlyMap<string, number>;
+declare type A1<Readonly> = Readonly;
+declare type B1<Partial> = Partial;
+declare type C1<NonNullable> = NonNullable;
+declare type D1<ReadonlyArray> = ReadonlyArray;
+declare type E1<ReturnType> = ReturnType;
+declare type F1<Record> = Record;
+declare type A2<T> = $ReadOnly<T>;
+declare type B2<T> = $Rest<T, {}>;
+declare type C2<T> = $NonMaybeType<T>;
+declare type D2<T> = $ReadOnlyArray<T>;
+declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
+declare type F2<T, U> = {| [key: T]: U |};
+"
+`;

--- a/src/__tests__/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.ts.snap
@@ -31,17 +31,8 @@ declare type C = $Diff<O, {| [key: U]: any |}>;
 `;
 
 exports[`should handle utility types 1`] = `
-"declare type A = $ReadOnly<{
-  a: number,
-  ...
-}>;
-declare type B = $Rest<
-  {
-    a: number,
-    ...
-  },
-  { ... }
->;
+"declare type A = $ReadOnly<{ a: number, ... }>;
+declare type B = $Rest<{ a: number, ... }, { ... }>;
 declare type C = $NonMaybeType<string | null>;
 declare type D = $ReadOnlyArray<string>;
 declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;
@@ -64,15 +55,8 @@ declare type F2<T, U> = { [key: T]: U, ... };
 `;
 
 exports[`should handle utility types 2`] = `
-"declare type A = $ReadOnly<{|
-  a: number,
-|}>;
-declare type B = $Rest<
-  {|
-    a: number,
-  |},
-  { ... }
->;
+"declare type A = $ReadOnly<{| a: number |}>;
+declare type B = $Rest<{| a: number |}, { ... }>;
 declare type C = $NonMaybeType<string | null>;
 declare type D = $ReadOnlyArray<string>;
 declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;

--- a/src/__tests__/__snapshots__/value-exports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/value-exports.spec.ts.snap
@@ -1,19 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle default exported es module values 1`] = `
-"declare var test: {
-  a: number,
-  ...
-};
+"declare var test: { a: number, ... };
 declare export default typeof test;
 "
 `;
 
 exports[`should handle exported es module values 1`] = `
-"declare var test: {
-  a: number,
-  ...
-};
+"declare var test: { a: number, ... };
 declare export { test };
 "
 `;

--- a/src/__tests__/__snapshots__/variables.spec.ts.snap
+++ b/src/__tests__/__snapshots__/variables.spec.ts.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle declares 1`] = `
-"declare var test: {
-  a: number,
-  ...
-};
+"declare var test: { a: number, ... };
 declare var foo: string;
 declare var bar: number;
 declare var baz: number;

--- a/src/__tests__/interfaces.spec.ts
+++ b/src/__tests__/interfaces.spec.ts
@@ -41,6 +41,12 @@ interface SpecialUser extends User {
   });
   expect(beautify(result3)).toMatchSnapshot();
   expect(result3).toBeValidFlowTypeDeclarations();
+
+  const result4 = compiler.compileDefinitionString(ts, {
+    inexact: false,
+  });
+  expect(beautify(result4)).toMatchSnapshot();
+  expect(result4).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle interface merging", () => {

--- a/src/__tests__/utility-types.spec.ts
+++ b/src/__tests__/utility-types.spec.ts
@@ -29,6 +29,13 @@ type F2<T, U> = Record<T, U>
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
+
+  const result2 = compiler.compileDefinitionString(ts, {
+    quiet: true,
+    inexact: false,
+  });
+  expect(beautify(result2)).toMatchSnapshot();
+  expect(result2).toBeValidFlowTypeDeclarations();
 });
 
 it("should handle Omit type", () => {

--- a/src/nodes/namespace.ts
+++ b/src/nodes/namespace.ts
@@ -101,9 +101,9 @@ export default class Namespace extends Node {
     if (childrenDeclarations.length > 0) {
       let topLevel = "";
       const nsGroup = `
-      declare var npm$namespace$${name}: {|
-        ${childrenDeclarations.map(declaration => `${declaration},`).join("\n")}
-      |}\n`;
+      declare var npm$namespace$${name}: ${printers.common.printExactObjectType(
+        childrenDeclarations,
+      )}\n`;
       if (namespace === "") {
         topLevel = `declare var ${name}: typeof npm$namespace$${name};\n`;
       }

--- a/src/printers/common.ts
+++ b/src/printers/common.ts
@@ -22,6 +22,35 @@ export const literalType = (node: RawNode): string => {
   return printers.node.printType(node.type);
 };
 
+/** Print as a Flow exact object type. */
+export const printExactObjectType = (members: string[]) => {
+  if (members.length === 0) {
+    return `{||}`;
+  } else if (members.length === 1) {
+    return `{|${members[0]}|}`;
+  } else {
+    return `{|\n${members.join(",\n")}\n|}`;
+  }
+};
+
+/** Print as a Flow inexact object type. */
+export const printInexactObjectType = (members: string[]) => {
+  if (members.length === 0) {
+    return `{...}`;
+  } else if (members.length === 1) {
+    return `{${members[0]}, ...}`;
+  } else {
+    return `{\n${members.join(",\n")},\n...\n}`;
+  }
+};
+
+/** Print as a Flow object type, applying the option `inexact`. */
+export const printDefaultObjectType = (members: string[]) => {
+  return opts().inexact
+    ? printInexactObjectType(members)
+    : printExactObjectType(members);
+};
+
 export const typeParameter = (
   node: ts.TypeParameterDeclaration & {
     withoutDefault: boolean;

--- a/src/printers/common.ts
+++ b/src/printers/common.ts
@@ -96,13 +96,11 @@ export const parameter = (
 
   if (!param.type) {
     if (param.name.kind === ts.SyntaxKind.ObjectBindingPattern) {
-      if (param.name.elements.length > 0) {
-        right = `{${param.name.elements
-          .map(element => `${printers.node.printType(element)}: any`)
-          .join(", ")}}`;
-      } else {
-        right = "{}";
-      }
+      right = printInexactObjectType(
+        param.name.elements.map(
+          element => `${printers.node.printType(element)}: any`,
+        ),
+      );
     } else {
       right = "any";
     }

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -203,21 +203,21 @@ export const enumDeclaration = (
   node: ts.EnumDeclaration,
 ): string => {
   const exporter = printers.relationships.exporter(node);
-  let members = "";
+  const members: string[] = [];
   // @ts-expect-error iterating over an iterator
   for (const [index, member] of node.members.entries()) {
-    let value;
+    let value: string;
     if (typeof member.initializer !== "undefined") {
       value = printers.node.printType(member.initializer);
     } else {
       value = index;
     }
-    members += `+${member.name.text}: ${value},\n`;
+    members.push(`+${member.name.text}: ${value}`);
   }
   return `
-declare ${exporter} var ${nodeName}: {|
-  ${members}
-|};\n`;
+declare ${exporter} var ${nodeName}: ${printers.common.printExactObjectType(
+    members,
+  )};\n`;
 };
 
 export const typeReference = (

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -117,20 +117,10 @@ const interfaceRecordType = (
   node: ts.InterfaceDeclaration,
   heritage: string,
 ): string => {
-  const isInexact = opts().inexact;
-  let members = typeMembers(node)
-    .map(m => `\n${m}`)
-    .join(",");
-
-  if (members.length > 0) {
-    members += "\n";
-  }
-
-  if (isInexact) {
-    return `{${heritage}${members}}`;
-  } else {
-    return `{|${heritage}${members}|}`;
-  }
+  const members = typeMembers(node);
+  return printers.common.printDefaultObjectType(
+    heritage ? [heritage, ...members] : members,
+  );
 };
 
 const classHeritageClause = withEnv<
@@ -195,7 +185,6 @@ const interfaceRecordDeclaration = (
           .join(",\n");
       })
       .join("");
-    heritage = heritage.length > 0 ? `${heritage},\n` : "";
   }
 
   const str = `${modifier}type ${nodeName}${printers.common.generics(

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -100,7 +100,7 @@ const classBody = <T>(
       mergedNamespaceChildren,
       nodeName,
     )) {
-      members.push(`static ${child}\n`);
+      members.push(`\nstatic ${child}`);
     }
   }
 

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -212,8 +212,7 @@ export const enumDeclaration = (
     } else {
       value = index;
     }
-    members += `+${member.name.text}: ${value},`;
-    members += `// ${value}\n`;
+    members += `+${member.name.text}: ${value},\n`;
   }
   return `
 declare ${exporter} var ${nodeName}: {|

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -76,9 +76,15 @@ export const typeMembers = (
     .filter(Boolean); // Filter rows which didn't print properly (private fields et al)
 };
 
-/** Print as a Flow object type. */
+/**
+ * Print as a Flow object type.
+ *
+ * If `forceInexact`, then print as an inexact object type.  Otherwise, the
+ * exactness will be governed by the `inexact` option.
+ */
 export const objectType = (
   node: ts.InterfaceDeclaration | ts.TypeLiteralNode,
+  forceInexact: boolean,
 ): string => {
   const isInexact = opts().inexact;
 
@@ -92,11 +98,7 @@ export const objectType = (
 
   const inner = members.join(",");
 
-  // we only want type literals to be exact. i.e. class Foo {} should not be class Foo {||}
-  if (!ts.isTypeLiteralNode(node)) {
-    return `{${inner}}`;
-  }
-  return isInexact ? `{${inner}}` : `{|${inner}|}`;
+  return isInexact || forceInexact ? `{${inner}}` : `{|${inner}|}`;
 };
 
 /** Print as a Flow interface type's body (the `{…}` portion.) */
@@ -249,7 +251,7 @@ export const interfaceDeclaration = (
 
     return `${modifier}type ${nodeName}${printers.common.generics(
       node.typeParameters,
-    )} = ${objectType(node)} ${heritage}`;
+    )} = ${objectType(node, true /* inexact so `&` works */)} ${heritage}`;
   } else {
     return `${modifier}interface ${nodeName}${printers.common.generics(
       node.typeParameters,

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -114,10 +114,9 @@ export const interfaceType = <T>(
 const interfaceRecordType = (
   node: ts.InterfaceDeclaration,
   heritage: string,
-  withSemicolons = false,
 ): string => {
   const isInexact = opts().inexact;
-  let members = typeMembers(node).join(withSemicolons ? ";" : ",");
+  let members = typeMembers(node).join(",");
 
   if (members.length > 0) {
     members += "\n";

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -71,7 +71,7 @@ export const typeMembers = (
       if (!printed) {
         return null;
       }
-      return "\n" + printers.common.jsdoc(member) + printed;
+      return printers.common.jsdoc(member) + printed;
     })
     .filter(Boolean); // Filter rows which didn't print properly (private fields et al)
 };
@@ -82,7 +82,7 @@ export const objectType = (
 ): string => {
   const isInexact = opts().inexact;
 
-  const members = typeMembers(node);
+  const members = typeMembers(node).map(m => `\n${m}`);
 
   if (isInexact) {
     members.push("...\n");
@@ -101,7 +101,7 @@ export const objectType = (
 
 /** Print as a Flow interface type's body (the `{…}` portion.) */
 const interfaceTypeBody = (node: ts.InterfaceDeclaration): string => {
-  const members = typeMembers(node);
+  const members = typeMembers(node).map(m => `\n${m}`);
   if (members.length > 0) {
     members.push("\n");
   }
@@ -116,7 +116,7 @@ const classBody = <T>(
   nodeName: string,
   mergedNamespaceChildren: ReadonlyArray<Node<T>>,
 ): string => {
-  const members = typeMembers(node);
+  const members = typeMembers(node).map(m => `\n${m}`);
 
   if (mergedNamespaceChildren.length > 0) {
     for (const child of Namespace.formatChildren(
@@ -141,7 +141,9 @@ const interfaceRecordType = (
   heritage: string,
 ): string => {
   const isInexact = opts().inexact;
-  let members = typeMembers(node).join(",");
+  let members = typeMembers(node)
+    .map(m => `\n${m}`)
+    .join(",");
 
   if (members.length > 0) {
     members += "\n";

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -59,15 +59,13 @@ export const variableDeclaration = (node: ts.VariableStatement): string => {
     .join("\n");
 };
 
-export const interfaceType = <T>(
+/**
+ * The members of the type, printed with their jsdoc.
+ */
+export const typeMembers = (
   node: ts.InterfaceDeclaration | ts.ClassDeclaration | ts.TypeLiteralNode,
-  nodeName: string,
-  mergedNamespaceChildren: ReadonlyArray<Node<T>>,
-  withSemicolons = false,
-  isType = false,
-): string => {
-  const isInexact = opts().inexact;
-  const members = node.members
+): string[] => {
+  return node.members
     .map(member => {
       const printed = printers.node.printType(member);
       if (!printed) {
@@ -76,6 +74,18 @@ export const interfaceType = <T>(
       return "\n" + printers.common.jsdoc(member) + printed;
     })
     .filter(Boolean); // Filter rows which didn't print properly (private fields et al)
+};
+
+export const interfaceType = <T>(
+  node: ts.InterfaceDeclaration | ts.ClassDeclaration | ts.TypeLiteralNode,
+  nodeName: string,
+  mergedNamespaceChildren: ReadonlyArray<Node<T>>,
+  withSemicolons = false,
+  isType = false,
+): string => {
+  const isInexact = opts().inexact;
+
+  const members = typeMembers(node);
 
   if (mergedNamespaceChildren.length > 0) {
     for (const child of Namespace.formatChildren(
@@ -107,16 +117,7 @@ const interfaceRecordType = (
   withSemicolons = false,
 ): string => {
   const isInexact = opts().inexact;
-  let members = node.members
-    .map(member => {
-      const printed = printers.node.printType(member);
-      if (!printed) {
-        return null;
-      }
-      return "\n" + printers.common.jsdoc(member) + printed;
-    })
-    .filter(Boolean) // Filter rows which didnt print propely (private fields et al)
-    .join(withSemicolons ? ";" : ",");
+  let members = typeMembers(node).join(withSemicolons ? ";" : ",");
 
   if (members.length > 0) {
     members += "\n";

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -76,15 +76,34 @@ export const typeMembers = (
     .filter(Boolean); // Filter rows which didn't print properly (private fields et al)
 };
 
-export const interfaceType = <T>(
-  node: ts.InterfaceDeclaration | ts.ClassDeclaration | ts.TypeLiteralNode,
-  nodeName: string,
-  mergedNamespaceChildren: ReadonlyArray<Node<T>>,
-  withSemicolons = false,
+export const interfaceType = (
+  node: ts.InterfaceDeclaration | ts.TypeLiteralNode,
   isType = false,
 ): string => {
   const isInexact = opts().inexact;
 
+  const members = typeMembers(node);
+
+  if (isType && isInexact) {
+    members.push("...\n");
+  } else if (members.length > 0) {
+    members.push("\n");
+  }
+
+  const inner = members.join(",");
+
+  // we only want type literals to be exact. i.e. class Foo {} should not be class Foo {||}
+  if (!ts.isTypeLiteralNode(node)) {
+    return `{${inner}}`;
+  }
+  return isInexact ? `{${inner}}` : `{|${inner}|}`;
+};
+
+const classBody = <T>(
+  node: ts.ClassDeclaration,
+  nodeName: string,
+  mergedNamespaceChildren: ReadonlyArray<Node<T>>,
+): string => {
   const members = typeMembers(node);
 
   if (mergedNamespaceChildren.length > 0) {
@@ -96,19 +115,13 @@ export const interfaceType = <T>(
     }
   }
 
-  if (isType && isInexact) {
-    members.push("...\n");
-  } else if (members.length > 0) {
+  if (members.length > 0) {
     members.push("\n");
   }
 
-  const inner = members.join(withSemicolons ? ";" : ",");
+  const inner = members.join(";");
 
-  // we only want type literals to be exact. i.e. class Foo {} should not be class Foo {||}
-  if (!ts.isTypeLiteralNode(node)) {
-    return `{${inner}}`;
-  }
-  return isInexact ? `{${inner}}` : `{|${inner}|}`;
+  return `{${inner}}`;
 };
 
 const interfaceRecordType = (
@@ -228,9 +241,6 @@ export const interfaceDeclaration = (
     node.typeParameters,
   )} ${type === "type" ? "= " : ""}${interfaceType(
     node,
-    nodeName,
-    [],
-    false,
     type === "type",
   )} ${heritage}`;
 
@@ -317,12 +327,7 @@ export const classDeclaration = <T>(
     node,
   )}class ${nodeName}${printers.common.generics(
     node.typeParameters,
-  )} ${heritage} ${interfaceType(
-    node,
-    nodeName,
-    mergedNamespaceChildren,
-    true,
-  )}`;
+  )} ${heritage} ${classBody(node, nodeName, mergedNamespaceChildren)}`;
 
   return str;
 };

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -113,16 +113,6 @@ const classBody = <T>(
   return `{${inner}}`;
 };
 
-const interfaceRecordType = (
-  node: ts.InterfaceDeclaration,
-  heritage: string,
-): string => {
-  const members = typeMembers(node);
-  return printers.common.printDefaultObjectType(
-    heritage ? [heritage, ...members] : members,
-  );
-};
-
 const classHeritageClause = withEnv<
   { classHeritage?: boolean },
   [ts.ExpressionWithTypeArguments],
@@ -173,23 +163,22 @@ const interfaceRecordDeclaration = (
   node: ts.InterfaceDeclaration,
   modifier: string,
 ): string => {
-  let heritage = "";
+  let members: string[] = [];
 
   // If the class is extending something
   if (node.heritageClauses) {
-    heritage = node.heritageClauses
-      .map(clause => {
-        return clause.types
-          .map(interfaceHeritageClause)
-          .map(type => `...$Exact<${type}>`)
-          .join(",\n");
-      })
-      .join("");
+    for (const clause of node.heritageClauses) {
+      for (const type of clause.types) {
+        members.push(`...$Exact<${interfaceHeritageClause(type)}>`);
+      }
+    }
   }
+
+  members = members.concat(typeMembers(node));
 
   const str = `${modifier}type ${nodeName}${printers.common.generics(
     node.typeParameters,
-  )} = ${interfaceRecordType(node, heritage)}\n`;
+  )} = ${printers.common.printDefaultObjectType(members)}\n`;
 
   return str;
 };

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -76,31 +76,6 @@ export const typeMembers = (
     .filter(Boolean); // Filter rows which didn't print properly (private fields et al)
 };
 
-/**
- * Print as a Flow object type.
- *
- * If `forceInexact`, then print as an inexact object type.  Otherwise, the
- * exactness will be governed by the `inexact` option.
- */
-export const objectType = (
-  node: ts.InterfaceDeclaration | ts.TypeLiteralNode,
-  forceInexact: boolean,
-): string => {
-  const isInexact = opts().inexact;
-
-  const members = typeMembers(node).map(m => `\n${m}`);
-
-  if (isInexact) {
-    members.push("...\n");
-  } else if (members.length > 0) {
-    members.push("\n");
-  }
-
-  const inner = members.join(",");
-
-  return isInexact || forceInexact ? `{${inner}}` : `{|${inner}|}`;
-};
-
 /** Print as a Flow interface type's body (the `{…}` portion.) */
 const interfaceTypeBody = (node: ts.InterfaceDeclaration): string => {
   const members = typeMembers(node).map(m => `\n${m}`);
@@ -251,7 +226,10 @@ export const interfaceDeclaration = (
 
     return `${modifier}type ${nodeName}${printers.common.generics(
       node.typeParameters,
-    )} = ${objectType(node, true /* inexact so `&` works */)} ${heritage}`;
+    )} = ${
+      // inexact so `&` works
+      printers.common.printInexactObjectType(typeMembers(node))
+    } ${heritage}`;
   } else {
     return `${modifier}interface ${nodeName}${printers.common.generics(
       node.typeParameters,

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -76,15 +76,15 @@ export const typeMembers = (
     .filter(Boolean); // Filter rows which didn't print properly (private fields et al)
 };
 
-export const interfaceType = (
+/** Print as a Flow object type. */
+export const objectType = (
   node: ts.InterfaceDeclaration | ts.TypeLiteralNode,
-  isType = false,
 ): string => {
   const isInexact = opts().inexact;
 
   const members = typeMembers(node);
 
-  if (isType && isInexact) {
+  if (isInexact) {
     members.push("...\n");
   } else if (members.length > 0) {
     members.push("\n");
@@ -97,6 +97,18 @@ export const interfaceType = (
     return `{${inner}}`;
   }
   return isInexact ? `{${inner}}` : `{|${inner}|}`;
+};
+
+/** Print as a Flow interface type's body (the `{…}` portion.) */
+const interfaceTypeBody = (node: ts.InterfaceDeclaration): string => {
+  const members = typeMembers(node);
+  if (members.length > 0) {
+    members.push("\n");
+  }
+
+  const inner = members.join(",");
+
+  return `{${inner}}`;
 };
 
 const classBody = <T>(
@@ -235,11 +247,11 @@ export const interfaceDeclaration = (
 
     return `${modifier}type ${nodeName}${printers.common.generics(
       node.typeParameters,
-    )} = ${interfaceType(node, true)} ${heritage}`;
+    )} = ${objectType(node)} ${heritage}`;
   } else {
     return `${modifier}interface ${nodeName}${printers.common.generics(
       node.typeParameters,
-    )} ${interfaceType(node, false)} `;
+    )} ${interfaceTypeBody(node)} `;
   }
 };
 

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -78,14 +78,8 @@ export const typeMembers = (
 
 /** Print as a Flow interface type's body (the `{…}` portion.) */
 const interfaceTypeBody = (node: ts.InterfaceDeclaration): string => {
-  const members = typeMembers(node).map(m => `\n${m}`);
-  if (members.length > 0) {
-    members.push("\n");
-  }
-
-  const inner = members.join(",");
-
-  return `{${inner}}`;
+  const members = typeMembers(node);
+  return members.length === 0 ? `{}` : `{\n${members.join(",\n")},\n}`;
 };
 
 const classBody = <T>(
@@ -93,24 +87,18 @@ const classBody = <T>(
   nodeName: string,
   mergedNamespaceChildren: ReadonlyArray<Node<T>>,
 ): string => {
-  const members = typeMembers(node).map(m => `\n${m}`);
+  const members = typeMembers(node);
 
   if (mergedNamespaceChildren.length > 0) {
     for (const child of Namespace.formatChildren(
       mergedNamespaceChildren,
       nodeName,
     )) {
-      members.push(`\nstatic ${child}`);
+      members.push(`static ${child}`);
     }
   }
 
-  if (members.length > 0) {
-    members.push("\n");
-  }
-
-  const inner = members.join(";");
-
-  return `{${inner}}`;
+  return members.length === 0 ? `{}` : `{\n${members.join(";\n")},\n}`;
 };
 
 const classHeritageClause = withEnv<

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -67,13 +67,15 @@ export const interfaceType = <T>(
   isType = false,
 ): string => {
   const isInexact = opts().inexact;
-  const members = node.members.map(member => {
-    const printed = printers.node.printType(member);
-    if (!printed) {
-      return null;
-    }
-    return "\n" + printers.common.jsdoc(member) + printed;
-  });
+  const members = node.members
+    .map(member => {
+      const printed = printers.node.printType(member);
+      if (!printed) {
+        return null;
+      }
+      return "\n" + printers.common.jsdoc(member) + printed;
+    })
+    .filter(Boolean); // Filter rows which didn't print properly (private fields et al)
 
   if (mergedNamespaceChildren.length > 0) {
     for (const child of Namespace.formatChildren(
@@ -90,9 +92,7 @@ export const interfaceType = <T>(
     members.push("\n");
   }
 
-  const inner = members
-    .filter(Boolean) // Filter rows which didn't print properly (private fields et al)
-    .join(withSemicolons ? ";" : ",");
+  const inner = members.join(withSemicolons ? ";" : ",");
 
   // we only want type literals to be exact. i.e. class Foo {} should not be class Foo {||}
   if (!ts.isTypeLiteralNode(node)) {

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -223,28 +223,24 @@ export const interfaceDeclaration = (
   if (isRecord) {
     return interfaceRecordDeclaration(nodeName, node, modifier);
   }
-  let heritage = "";
 
-  // If the class is extending something
   if (node.heritageClauses) {
-    heritage = node.heritageClauses
+    // The interface is extending something.
+    let heritage = node.heritageClauses
       .map(clause => {
         return clause.types.map(interfaceHeritageClause).join(" & ");
       })
       .join("");
     heritage = heritage.length > 0 ? `& ${heritage}\n` : "";
+
+    return `${modifier}type ${nodeName}${printers.common.generics(
+      node.typeParameters,
+    )} = ${interfaceType(node, true)} ${heritage}`;
+  } else {
+    return `${modifier}interface ${nodeName}${printers.common.generics(
+      node.typeParameters,
+    )} ${interfaceType(node, false)} `;
   }
-
-  const type = node.heritageClauses ? "type" : "interface";
-
-  const str = `${modifier}${type} ${nodeName}${printers.common.generics(
-    node.typeParameters,
-  )} ${type === "type" ? "= " : ""}${interfaceType(
-    node,
-    type === "type",
-  )} ${heritage}`;
-
-  return str;
 };
 
 export const typeDeclaration = (

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -252,15 +252,12 @@ export const classDeclaration = <T>(
   mergedNamespaceChildren: ReadonlyArray<Node<T>>,
 ): string => {
   let heritage = "";
-
-  // If the class is extending something
   if (node.heritageClauses) {
+    // The class is extending and/or implementing something.
     heritage = node.heritageClauses
-      .map(clause => {
-        return clause.types.map(classHeritageClause).join(", ");
-      })
+      .map(clause => clause.types.map(classHeritageClause).join(", "))
       .join(", ");
-    heritage = heritage.length > 0 ? `mixins ${heritage}` : "";
+    heritage = `mixins ${heritage}`;
   }
 
   const members = typeMembers(node);

--- a/src/printers/identifiers.ts
+++ b/src/printers/identifiers.ts
@@ -50,10 +50,10 @@ const identifiers: { [name: string]: IdentifierResult } = {
   },
   Record,
   Omit: ([obj, keys]: [any, any]) => {
-    return `$Diff<${printers.node.printType(obj)},${Record(
-      [keys, { kind: ts.SyntaxKind.AnyKeyword }],
-      false,
-    )}>`;
+    const members = recordMembers(keys, { kind: ts.SyntaxKind.AnyKeyword });
+    return `$Diff<${printers.node.printType(
+      obj,
+    )},${printers.common.printExactObjectType(members)}>`;
   },
 };
 

--- a/src/printers/identifiers.ts
+++ b/src/printers/identifiers.ts
@@ -1,7 +1,6 @@
 // Please add only built-in type references
 
 import * as printers from "./index";
-import { opts } from "../options";
 import { withEnv } from "../env";
 import ts from "typescript";
 
@@ -33,10 +32,9 @@ const identifiers: { [name: string]: IdentifierResult } = {
   RegExpMatchArray: "RegExp$matchResult",
   NonNullable: "$NonMaybeType",
   Partial: ([type]: any[]) => {
-    const isInexact = opts().inexact;
-    return `$Rest<${printers.node.printType(type)}, {${
-      isInexact ? "..." : ""
-    }}>`;
+    return `$Rest<${printers.node.printType(
+      type,
+    )}, ${printers.common.printInexactObjectType([])}>`;
   },
   ReturnType: (typeArguments: any[]) => {
     return `$Call<<R>((...args: any[]) => R) => R, ${printers.node.printType(

--- a/src/printers/identifiers.ts
+++ b/src/printers/identifiers.ts
@@ -5,28 +5,27 @@ import { opts } from "../options";
 import { withEnv } from "../env";
 import ts from "typescript";
 
-const Record = ([key, value]: [any, any], isInexact = opts().inexact) => {
+const recordMembers = (key, value) => {
   const valueType = printers.node.printType(value);
 
   switch (key.kind) {
     case ts.SyntaxKind.LiteralType:
-      return `{ ${printers.node.printType(key)}: ${valueType}${
-        isInexact ? ", ..." : ""
-      }}`;
+      return [`${printers.node.printType(key)}: ${valueType}`];
     case ts.SyntaxKind.UnionType:
       if (key.types.every(t => t.kind === ts.SyntaxKind.LiteralType)) {
-        const fields = key.types.reduce((acc, t) => {
-          acc += `${printers.node.printType(t)}: ${valueType},\n`;
-          return acc;
-        }, "");
-        return `{ ${fields}${isInexact ? "..." : ""}}`;
+        return key.types.map(
+          t => `${printers.node.printType(t)}: ${valueType}`,
+        );
       }
     // Fallthrough
     default:
-      return `{[key: ${printers.node.printType(key)}]: ${valueType}${
-        isInexact ? ", ..." : ""
-      }}`;
+      return [`[key: ${printers.node.printType(key)}]: ${valueType}`];
   }
+};
+
+const Record = ([key, value]: [any, any], isInexact = opts().inexact) => {
+  const members = recordMembers(key, value);
+  return `{ ${members.join(",\n")}${isInexact ? ", ..." : ""} }`;
 };
 
 type IdentifierResult = string | ((...args: any[]) => any);

--- a/src/printers/identifiers.ts
+++ b/src/printers/identifiers.ts
@@ -23,11 +23,6 @@ const recordMembers = (key, value) => {
   }
 };
 
-const Record = ([key, value]: [any, any], isInexact = opts().inexact) => {
-  const members = recordMembers(key, value);
-  return `{ ${members.join(",\n")}${isInexact ? ", ..." : ""} }`;
-};
-
 type IdentifierResult = string | ((...args: any[]) => any);
 
 const identifiers: { [name: string]: IdentifierResult } = {
@@ -48,7 +43,10 @@ const identifiers: { [name: string]: IdentifierResult } = {
       typeArguments[0],
     )}>`;
   },
-  Record,
+  Record: ([keys, value]: [any, any]) => {
+    const members = recordMembers(keys, value);
+    return printers.common.printDefaultObjectType(members);
+  },
   Omit: ([obj, keys]: [any, any]) => {
     const members = recordMembers(keys, { kind: ts.SyntaxKind.AnyKeyword });
     return `$Diff<${printers.node.printType(

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -498,7 +498,7 @@ export const printType = withEnv<any, [any], string>(
         return printers.functions.functionType(type);
 
       case ts.SyntaxKind.TypeLiteral:
-        return printers.declarations.objectType(type);
+        return printers.declarations.objectType(type, false);
 
       //case SyntaxKind.IdentifierObject:
       //case SyntaxKind.StringLiteralType:

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -7,7 +7,6 @@ import * as logger from "../logger";
 import { withEnv } from "../env";
 import { renames, getLeftMostEntityName } from "./smart-identifiers";
 import { printErrorMessage } from "../errors/error-message";
-import { opts } from "../options";
 
 type ExpectedKeywordKind =
   | ts.SyntaxKind.AnyKeyword
@@ -771,13 +770,9 @@ export const printType = withEnv<any, [any], string>(
           return type.types.map(printType).join(" & ");
         }
 
-        const spreadType = type.types
-          .map(type => `...${printType(type)}`)
-          .join(",");
-
-        const isInexact = opts().inexact;
-
-        return isInexact ? `{ ${spreadType} }` : `{| ${spreadType} |}`;
+        return printers.common.printDefaultObjectType(
+          type.types.map(type => `...${printType(type)}`),
+        );
       }
 
       case ts.SyntaxKind.MethodDeclaration:

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -498,7 +498,7 @@ export const printType = withEnv<any, [any], string>(
         return printers.functions.functionType(type);
 
       case ts.SyntaxKind.TypeLiteral:
-        return printers.declarations.interfaceType(type, "", [], false, true);
+        return printers.declarations.interfaceType(type, true);
 
       //case SyntaxKind.IdentifierObject:
       //case SyntaxKind.StringLiteralType:

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -498,7 +498,9 @@ export const printType = withEnv<any, [any], string>(
         return printers.functions.functionType(type);
 
       case ts.SyntaxKind.TypeLiteral:
-        return printers.declarations.objectType(type, false);
+        return printers.common.printDefaultObjectType(
+          printers.declarations.typeMembers(type),
+        );
 
       //case SyntaxKind.IdentifierObject:
       //case SyntaxKind.StringLiteralType:

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -498,7 +498,7 @@ export const printType = withEnv<any, [any], string>(
         return printers.functions.functionType(type);
 
       case ts.SyntaxKind.TypeLiteral:
-        return printers.declarations.interfaceType(type, true);
+        return printers.declarations.objectType(type);
 
       //case SyntaxKind.IdentifierObject:
       //case SyntaxKind.StringLiteralType:


### PR DESCRIPTION
In Flow syntax, a type like `{| x: number |}` means an [exact object type](https://flow.org/en/docs/types/objects/#toc-exact-object-types), while `{ x: number, ... }` means an inexact object type.

The form `{ x: number }`, with neither bars `|` nor an ellipsis, is ambiguous -- it can mean either an exact or inexact object type, depending on the Flow configuration. See docs:
https://flow.org/en/docs/types/objects/#toc-explicit-inexact-object-types
So we should avoid emitting that form, and always emit one of the explicit forms.

In several important places, we already make sure to always emit a type that's explicitly either exact or inexact. But there are still places where we emit the ambiguous form. I count 5 of them where we do so and assume it means an inexact type (as it did in early versions of Flow, and currently still does by default); and 2 of them where we assume the opposite, that it means an exact type (which is the modern recommended configuration, and is planned to become the default in the future.) That means that regardless of Flow configuration, the current output will be wrong in some places.

In this PR, I fix all 7 of those bugs. The first step is to introduce three small helpers:
```js
/** Print as a Flow exact object type. */
export const printExactObjectType = (members: string[]) => // …

/** Print as a Flow inexact object type. */
export const printInexactObjectType = (members: string[]) => // …

/** Print as a Flow object type, applying the option `inexact`. */
export const printDefaultObjectType = (members: string[]) => // …
```
which always make sure to produce an explicit form. Then each of the separate implementations we have of printing a Flow object type, at a number of different spots in our code, get replaced with a call to one of those.

In addition to fixing those seven bugs, this generally simplifies the code at each of those sites; for example, instead of 5 different spots where we consult the `inexact` option, there's now one central such spot, in `printDefaultObjectType`. The overall diffstat on non-test code is:
```
$ git diff --shortstat upstream src/[a-z]*
 5 files changed, 119 insertions(+), 151 deletions(-)
```

The new helpers also keep the formatting more compact, using a single line if the object type has just a single member. Many snapshots get updated as a result. The total diffstat including tests is:
```
$ git diff --shortstat upstream
 22 files changed, 253 insertions(+), 369 deletions(-)
```

At the end of the branch, we add a line `implicit-inexact-object=error` to the `.flowconfig` used in tests. This causes Flow to verify that we haven't produced any of the ambiguous form, each time that we ask it to check our test output for validity.

---

This is a PR that will definitely be easier to read one commit at a time than all as one diff. I'd also be happy to split it up into several PRs, if that'd be helpful.

The gnarliest part of developing this series of fixes was in `src/printers/declarations.ts`; particularly around the function `interfaceType`, which had complicated logic because it was really doing about four different jobs. The logic that's truly in common between those becomes a new smaller helper `typeMembers`, and then the call sites of `interfaceType` mostly turn into calls to `typeMembers` followed by calls to one or another of the `print*ObjectType` functions. The work of disentangling `interfaceType` that way happens mostly in a series of NFC commits (a term I appreciate learning from the [LLVM community](https://twitter.com/clattner_llvm/status/1045548372134846464), and described [here](https://github.com/zulip/zulip-mobile/blob/main/docs/glossary.md#nfc)), followed by a small behavior-changing commit fixing each of its call sites.
