### PR TITLE
fix: add support for implements within classes

### DIFF
--- a/src/__tests__/__snapshots__/classes.spec.ts.snap
+++ b/src/__tests__/__snapshots__/classes.spec.ts.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should handle class extends 1`] = `
+"declare class extension {
+  getString(): string;
+}
+declare class extender mixins extension {
+  getNumber(): number;
+}
+"
+`;
+
+exports[`should handle class implements 1`] = `
+"declare interface implementation {
+  getString(): string;
+}
+declare class implementor implements implementation {
+  getString(): string;
+}
+"
+`;
+
+exports[`should handle class implements and extends 1`] = `
+"declare interface implementation1 {
+  getString(): string;
+}
+declare interface implementation2 {
+  getNumber(): number;
+}
+declare class extension {}
+declare class implementor
+  mixins extension
+  implements implementation1, implementation2
+{
+  getString(): string;
+  getNumber(): number;
+}
+"
+`;
+
 exports[`should handle static methods ES6 classes 1`] = `
 "declare class Subscribable<T> {}
 declare class Operator<T, R> {}

--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -280,7 +280,7 @@ declare class A$B$D<S> {}
 declare var npm$namespace$A$B$C: {|
   N: typeof A$B$C$N,
 |};
-declare class A$B$C$N<A> mixins A$B$D<A>, A$B$S<A> {
+declare class A$B$C$N<A> mixins A$B$D<A> implements A$B$S<A> {
   a: string;
 }
 "

--- a/src/__tests__/classes.spec.ts
+++ b/src/__tests__/classes.spec.ts
@@ -29,3 +29,50 @@ it("should handle static methods ES6 classes", () => {
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle class extends", () => {
+  const ts = `
+  class extension {
+    getString(): string
+  }
+  class extender extends extension {
+    getNumber(): number
+  }
+  `;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should handle class implements", () => {
+  const ts = `
+  interface implementation {
+    getString(): string
+  }
+  class implementor implements implementation {
+    getString(): string
+  }
+  `;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should handle class implements and extends", () => {
+  const ts = `
+  interface implementation1 {
+    getString(): string
+  }
+  interface implementation2 {
+    getNumber(): number
+  }
+  class extension {}
+  class implementor extends extension implements implementation1, implementation2 {
+    getString(): string
+    getNumber(): number
+  }
+  `;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});


### PR DESCRIPTION
Add support for implements within classes. Currently if implementing an interface it becomes a mixin which isn't accurate.  When TypeScript implements an interface it should remain an "implements".

Please double check the change to [namespaces.spec.ts.snap](https://github.com/joarwilk/flowgen/pull/186/commits/9e38d801681a2257d56232b07eaf4a0a3a3592e2#diff-23434b74c83ffbe22a6b9436f108510d851317368395deaaf24b58e67e751c41) this is the only one I'm iffy about but I believe it was wrong originally

[References issue](https://github.com/joarwilk/flowgen/issues/124)