### PR TITLE
add type in converted type imports

### DIFF
--- a/src/__tests__/__snapshots__/imports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/imports.spec.ts.snap
@@ -7,9 +7,9 @@ declare type S = typeof $Flowgen$Import$http;
 `;
 
 exports[`should handle imports 1`] = `
-"import { GeneratorOptions } from \\"@babel/generator\\";
-import traverse, { Visitor, NodePath } from \\"@babel/traverse\\";
-import { Visitor as NewVisitor } from \\"@babel/traverse\\";
+"import { type GeneratorOptions } from \\"@babel/generator\\";
+import traverse, { type Visitor, NodePath } from \\"@babel/traverse\\";
+import { type Visitor as NewVisitor } from \\"@babel/traverse\\";
 import template from \\"@babel/template\\";
 import * as t from \\"@babel/types\\";
 import v, * as d from \\"typescript\\";


### PR DESCRIPTION
In typescript it is possible to mix type and value imports, which currently is not correctly converted to flow.

This change adds logic to check if import for type and if so adds "type" in import.