### PR TITLE
Do not apply exactness to types containing indexers

### DIFF
--- a/src/__tests__/__snapshots__/classes.spec.ts.snap
+++ b/src/__tests__/__snapshots__/classes.spec.ts.snap
@@ -57,7 +57,6 @@ declare class Observable<T> mixins Subscribable<T> {
   static +jump?: () => void;
   cfnProperties: {
     [key: string]: any,
-    ...
   };
   static fooGet: string;
 }

--- a/src/__tests__/__snapshots__/indexers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/indexers.spec.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle indexers 1`] = `
+"declare type Map = {
+  [key: string]: number,
+};
+"
+`;
+
+exports[`should handle indexers 2`] = `
+"declare type Map = {
+  [key: string]: number,
+};
+"
+`;

--- a/src/__tests__/indexers.spec.ts
+++ b/src/__tests__/indexers.spec.ts
@@ -1,0 +1,24 @@
+import { compiler, beautify } from "..";
+import "../test-matchers";
+
+it("should handle indexers", () => {
+  const ts = `
+type Map = {
+  [key: string]: number
+}
+`;
+  {
+    const result = compiler.compileDefinitionString(ts, { quiet: true });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+
+  {
+    const result = compiler.compileDefinitionString(ts, {
+      quiet: true,
+      inexact: false,
+    });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+});


### PR DESCRIPTION
I believe I have found an edge case affecting those using older versions of Flow (<0.126.0), which this PR aims to solve.

It's easiest to see what this PR does with some examples:

<table>
  <tr>
    <td><strong>TypeScript input</strong></td>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>

<td>

```ts
type Map = {
  [key: string]: string;
};
```

</td>

<td>

```js
type Map = {
  [key: string]: string,
  ...
};
```

The `...` here is ignored by Flow, so it can be removed

</td>

<td>

```js
type Map = {
  [key: string]: string,
};
```

</td>
  </tr>
  <tr>
    <td>Same as above with <code>--no-inexact</code></td>
    <td>


```js
type Map = {|
  [key: string]: string,
|};
```

Using indexers in exact objects was unsupported in Flow [up until v0.126.0](https://github.com/facebook/flow/blob/main/Changelog.md#01260).

</td>

<td>

```js
type Map = {
  [key: string]: string,
};
```

Same as above; no exact syntax for types containing indexers. 

An "exact" object with an indexer doesn't really make sense, since the purpose of the indexer is to allow you to provide arbitrary keys, so removing exactness from an object with an indexer should be a no-op in Flow >=0.126.0 and should fix unusable types for older Flow versions

</td>
  </tr>
  
</table>

 Thank you so much to all the contributors! ❤️  `flowgen` is a fantastic tool!
