### PR TITLE
Add test for bigint support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^25.3.4",
     "eslint-plugin-prettier": "^4.0.0",
-    "flow-bin": "^0.161.0",
+    "flow-bin": "^0.195.0",
     "jest": "^27.4.7",
     "mongodb": "^4.1.3"
   },

--- a/src/__tests__/__snapshots__/bigint-literals.spec.ts.snap
+++ b/src/__tests__/__snapshots__/bigint-literals.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle bigint literals in type 1`] = `
+"declare type MyBigType = number;
+declare type bigint_like = number | number | string;
+"
+`;

--- a/src/__tests__/__snapshots__/bigint-literals.spec.ts.snap
+++ b/src/__tests__/__snapshots__/bigint-literals.spec.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle bigint literals in type 1`] = `
-"declare type MyBigType = number;
-declare type bigint_like = number | number | string;
+"declare type MyBigType = bigint;
+declare type bigint_like = number | bigint | string;
+declare var literal: 9007199254740991n;
 "
 `;

--- a/src/__tests__/bigint-literals.spec.ts
+++ b/src/__tests__/bigint-literals.spec.ts
@@ -3,14 +3,26 @@ import "../test-matchers";
 
 it("should handle bigint literals in type", () => {
   const ts = `
-  type MyBigType = bigint;
-  type bigint_like = number | bigint | string;
-  
-  // these are not supported by flowgen yet
-  // but we should test them once they are supported
-  // const literal = 9007199254740991n;
-  // const ctor = BigInt("9007199254740991"); // 9007199254740991n
-`;
+    type MyBigType = bigint;
+    type bigint_like = number | bigint | string;
+    const literal = 9007199254740991n;
+  `;
+
+  // unsupported expressions that should be supported
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+  // const ts = `
+  //   const ctor = BigInt("9007199254740991");
+  //   const add = 4n + 5n;
+  //   const mult = 4n * 5n;
+  //   const sub = 4n - 5n;
+  //   const mod = 4n % 3n;
+  //   const exp = 4n ** 2n;
+  //   const div = 4n / 2n;
+  //   const eq = 4n == 0;
+  //   const cmp = 4n > 0;
+  //   const mixed = [4n, 6, -12n, 10, 4, 0, 0n];
+  //   const boolCast = !12n;
+  // `;
 
   const result = compiler.compileDefinitionString(ts, { quiet: true });
 

--- a/src/__tests__/bigint-literals.spec.ts
+++ b/src/__tests__/bigint-literals.spec.ts
@@ -1,0 +1,19 @@
+import { compiler, beautify } from "..";
+import "../test-matchers";
+
+it("should handle bigint literals in type", () => {
+  const ts = `
+  type MyBigType = bigint;
+  type bigint_like = number | bigint | string;
+  
+  // these are not supported by flowgen yet
+  // but we should test them once they are supported
+  // const literal = 9007199254740991n;
+  // const ctor = BigInt("9007199254740991"); // 9007199254740991n
+`;
+
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/errors/error-message.ts
+++ b/src/errors/error-message.ts
@@ -5,9 +5,6 @@ export type ErrorMessage =
       readonly type: "UnsupportedComputedProperty";
     }
   | {
-      readonly type: "UnsupportedBigInt";
-    }
-  | {
       readonly type: "UnsupportedUniqueSymbol";
     }
   | {
@@ -39,9 +36,6 @@ export function printErrorMessage(error: ErrorMessage): string {
   switch (error.type) {
     case "UnsupportedComputedProperty":
       return "Flow doesn't support computed property names";
-
-    case "UnsupportedBigInt":
-      return "Flow doesn't support BigInt proposal: https://github.com/facebook/flow/issues/6639";
 
     case "UnsupportedUniqueSymbol":
       return "Flow doesn't support `unique symbol`";

--- a/src/printers/basics.ts
+++ b/src/printers/basics.ts
@@ -3,6 +3,7 @@ const types: {
 } = {
   VoidKeyword: "void",
   StringKeyword: "string",
+  BigIntKeyword: "bigint",
   AnyKeyword: "any",
   NumberKeyword: "number",
   BooleanKeyword: "boolean",

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -28,6 +28,7 @@ type ExpectedKeywordKind =
 type PrintNode =
   | ts.KeywordToken<ExpectedKeywordKind>
   | { kind: typeof ts.SyntaxKind.FirstLiteralToken }
+  | { kind: ts.SyntaxKind.BigIntLiteral; text: string }
   | ts.CallSignatureDeclaration
   | ts.ConstructorDeclaration
   | ts.TypeParameterDeclaration
@@ -432,10 +433,7 @@ export const printType = withEnv<any, [any], string>(
         // TODO: What to print here?
         return "Symbol";
       case ts.SyntaxKind.BigIntKeyword:
-        logger.error(type, { type: "UnsupportedBigInt" });
-        // TODO: What to print here?
-        return "number";
-
+        return printers.basics.print(kind);
       // JSDoc types
       case ts.SyntaxKind.JSDocAllType:
         return "*";
@@ -588,6 +586,9 @@ export const printType = withEnv<any, [any], string>(
         }
         return `$ObjMapi<${source}, <${typeName}>(${typeName}) => ${value}>`;
       }
+
+      case ts.SyntaxKind.BigIntLiteral:
+        return type.text;
 
       case ts.SyntaxKind.FirstLiteralToken:
         // @ts-expect-error todo(flow->ts)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,10 +2755,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
 
-flow-bin@^0.161.0:
-  version "0.161.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.161.0.tgz#1c03ea4a9e3036a8bc639f050bd8dc6f5288e8bb"
-  integrity sha512-5BKQi+sjOXz67Kbc1teiBwd5e0Da6suW7S5oUCm9VclnzSZ3nlfNZUdrkvgJ5S4w5KDBDToEL7rREpn8rKF1zg==
+flow-bin@^0.195.0:
+  version "0.195.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.0.tgz#67075596cc4ef2560ec001d5c781b07777f05f81"
+  integrity sha512-VGIwDVxcZRLbc2k8dsMcdHHjrPDzr1frqGvpRdYpdnpK/qi4heHFGDU747NElcsNiqyzs+G8gaZmhxZiBvwyUg==
 
 form-data@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Flow 0.195.0 introduced bigint support

This PR just bumps the flow-bin version and adds the test to make sure these work properly in flowgen

I didn't add support for some of the more complex types, but that can be done as a follow-up PR