### PR TITLE
Add missing flow utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It's surprisingly robust and non-lossy as it stands right now, in big part thank
 | ✅ | Variance | `interface A { readonly b: B, c: C }` | `interface A { +b: B, c: C }` |
 | ✅ | Functions | `(a: A, b: B) => C` | `(a: A, b: B) => C` |
 | ✅ | Indexers | `{[k: string]: string}` | `{[k: string]: string}` |
-|    | This type | `(this: X, a: A, b: B) => C` | `(a: A, b: B) => C` |
+| ✅ | This type | `(this: X, a: A, b: B) => C` | `(this: X, a: A, b: B) => C` |
 |    | Type guards | `(a: X) => a is A` | `(a: X) => boolean` |
 | ✅ | Type parameter bounds | `function f<A extends string>(a:A){}` | `function f<A: string>(a:A){}` |
 | ✅ | keyof X | `keyof X` | `$Keys<X>` |

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ It's surprisingly robust and non-lossy as it stands right now, in big part thank
 | ✅ | ReadonlySet | `ReadonlySet<X>` | `$ReadOnlySet<X>` |
 | ✅ | ReadonlyMap | `ReadonlyMap<X, Y>` | `$ReadOnlyMap<X, Y>` |
 | ✅ | Record | `Record<K, T>` | `{ [key: K]: T }` |
-|    | Pick | `Pick<T, K>` |  |
-|    | Exclude | `Exclude<T, U>` |  |
-|    | Extract | `Extract<T, U>` |  |
+| ✅ | Pick | `Pick<T, K>` | `Pick<T, K>` |
+| ✅ | Exclude | `Exclude<T, U>` | `Exclude<T, U>` |
+| ✅ | Extract | `Extract<T, U>` | `Extract<T, U>` |
 | ✅ | NonNullable | `NonNullable<X>` | `$NonMaybeType<X>` |
 | ✅ | ReturnType | `ReturnType<F>` | `$Call<<R>((...args: any[]) => R) => R, F>` |
 |    | InstanceType | `InstanceType<X>` |  |
-|    | Required | `Required<X>` |  |
+| ✅ | Required | `Required<X>` | `Required<X>` |
 |    | ThisType | `ThisType<X>` |  |
 | ✅ | T['string'] | `T['string']` | `$PropertyType<T, k>` |
 | ✅ | T[k] | `T[k]` | `$ElementType<T, k>` |

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ It's surprisingly robust and non-lossy as it stands right now, in big part thank
 | ✅ | Pick | `Pick<T, K>` | `Pick<T, K>` |
 | ✅ | Exclude | `Exclude<T, U>` | `Exclude<T, U>` |
 | ✅ | Extract | `Extract<T, U>` | `Extract<T, U>` |
+| ✅ | Omit | `Omit<T, U>` | `Omit<T, U>` |
 | ✅ | NonNullable | `NonNullable<X>` | `$NonMaybeType<X>` |
-| ✅ | ReturnType | `ReturnType<F>` | `$Call<<R>((...args: any[]) => R) => R, F>` |
+| ✅ | ReturnType | `ReturnType<F>` | `ReturnType<F>` |
 |    | InstanceType | `InstanceType<X>` |  |
 | ✅ | Required | `Required<X>` | `Required<X>` |
 |    | ThisType | `ThisType<X>` |  |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It's surprisingly robust and non-lossy as it stands right now, in big part thank
 |    | Type guards | `(a: X) => a is A` | `(a: X) => boolean` |
 | ✅ | Type parameter bounds | `function f<A extends string>(a:A){}` | `function f<A: string>(a:A){}` |
 | ✅ | keyof X | `keyof X` | `$Keys<X>` |
-| ✅ | X[keyof X] | `X[keyof X]` | `$ElementType<X, $Keys<X>>` |
+| ✅ | X[keyof X] | `X[keyof X]` | `X[$Keys<X>]` |
 | ✅ | Partial | `Partial<X>` | `$Rest<X, {}>` |
 | ✅ | Readonly | `Readonly<X>` | `$ReadOnly<X>` |
 | ✅ | ReadonlyArray | `ReadonlyArray<X>` | `$ReadOnlyArray<X>` |
@@ -35,9 +35,9 @@ It's surprisingly robust and non-lossy as it stands right now, in big part thank
 |    | InstanceType | `InstanceType<X>` |  |
 | ✅ | Required | `Required<X>` | `Required<X>` |
 |    | ThisType | `ThisType<X>` |  |
-| ✅ | T['string'] | `T['string']` | `$PropertyType<T, k>` |
-| ✅ | T[k] | `T[k]` | `$ElementType<T, k>` |
-| ✅ | Mapped types | `{[K in keyof Obj]: Obj[K]}` | `$ObjMapi<Obj, <K>(K) => $ElementType<Obj, K>>` |
+| ✅ | T['string'] | `T['string']` | `T['string']` |
+| ✅ | T[k] | `T[k]` | `T[k]` |
+| ✅ | Mapped types | `{[K in keyof Obj]: Obj[K]}` | `$ObjMapi<Obj, <K>(K) => Obj[K]>` |
 |    | Conditional types | `A extends B ? C : D` | `any` |
 | ✅ | typeof operator | `typeof foo` | `typeof foo` |
 | ✅ | Tuple type | `[number, string]` | `[number, string]` |

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^25.3.4",
     "eslint-plugin-prettier": "^4.0.0",
-    "flow-bin": "^0.195.0",
+    "flow-bin": "^0.217.2",
     "jest": "^27.4.7",
     "mongodb": "^4.1.3"
   },

--- a/src/__tests__/__snapshots__/duplicated-names.spec.ts.snap
+++ b/src/__tests__/__snapshots__/duplicated-names.spec.ts.snap
@@ -13,10 +13,9 @@ declare export var AuthMechanism: {
   +MONGODB_CR: \\"MONGODB-CR\\",
   ...
 };
-export type AuthMechanismType1 = $ElementType<
-  typeof AuthMechanism,
-  $Keys<typeof AuthMechanism>
->;
+export type AuthMechanismType1 = (typeof AuthMechanism)[$Keys<
+  typeof AuthMechanism
+>];
 "
 `;
 
@@ -26,10 +25,9 @@ exports[`should handle variable & type having same name 1`] = `
   +MONGODB_CR: \\"MONGODB-CR\\",
   ...
 };
-export type AuthMechanismType = $ElementType<
-  typeof AuthMechanism,
-  $Keys<typeof AuthMechanism>
->;
+export type AuthMechanismType = (typeof AuthMechanism)[$Keys<
+  typeof AuthMechanism
+>];
 "
 `;
 
@@ -38,10 +36,9 @@ exports[`should support generic type rename 1`] = `
   +off: \\"off\\",
   ...
 }>;
-export type ProfilingLevelType = $ElementType<
-  typeof ProfilingLevel,
-  $Keys<typeof ProfilingLevel>
->;
+export type ProfilingLevelType = (typeof ProfilingLevel)[$Keys<
+  typeof ProfilingLevel
+>];
 export type Callback<T = any> = (error?: Error, result?: T) => void;
 declare export var callback: Callback<ProfilingLevelType>;
 "

--- a/src/__tests__/__snapshots__/function-exports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/function-exports.spec.ts.snap
@@ -46,17 +46,24 @@ declare export function toString(b: string): void;
 "
 `;
 
+exports[`should keep default parameters in functions 1`] = `
+"declare function addClickListener<T = Error>(onclick: (e: Event) => void): T;
+"
+`;
+
+exports[`should keep this annotation in functions 1`] = `
+"declare function addClickListener(
+  onclick: (this: void, e: Event) => void
+): void;
+"
+`;
+
 exports[`should not break with Promise return types - issue 156 1`] = `
 "declare export var fn: () => Promise<void>;
 "
 `;
 
-exports[`should remove default parameters from functions 1`] = `
-"declare function addClickListener<T>(onclick: (e: Event) => void): T;
-"
-`;
-
-exports[`should remove this annotation from functions 1`] = `
-"declare function addClickListener(onclick: (e: Event) => void): void;
+exports[`should transform generic \`<T extends E>\` to \`<T: E>\` on functions 1`] = `
+"declare function addClickListener<T: Error>(onclick: (e: Event) => void): T;
 "
 `;

--- a/src/__tests__/__snapshots__/interfaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/interfaces.spec.ts.snap
@@ -139,23 +139,23 @@ exports[`should handle untyped object binding pattern 1`] = `
 "
 `;
 
-exports[`should remove generic defaults in call signature 1`] = `
+exports[`should keep generic defaults in call signature 1`] = `
 "declare interface AbstractLevelDOWN<K, V> {}
 declare interface AbstractLevelDOWNConstructor {
-  <K, V>(location: string): AbstractLevelDOWN<K, V>;
+  <K = any, V = any>(location: string): AbstractLevelDOWN<K, V>;
 }
 "
 `;
 
-exports[`should remove this in call signature 1`] = `
+exports[`should keep this in call signature 1`] = `
 "declare interface Arc<This, Datum> {
-  (d: Datum, ...args: any[]): string | null;
+  (this: This, d: Datum, ...args: any[]): string | null;
 }
 declare interface D<This, Datum> {
-  new(d: Datum, ...args: any[]): void;
+  new(this: D<This, Datum>, d: Datum, ...args: any[]): void;
 }
 declare interface C<This, Datum> {
-  (d: Datum, ...args: any[]): any;
+  (this: This, d: Datum, ...args: any[]): any;
 }
 "
 `;

--- a/src/__tests__/__snapshots__/mapped-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/mapped-types.spec.ts.snap
@@ -15,10 +15,7 @@ declare type MappedUnion = $ObjMapi<
   { [k: SourceUnion]: any },
   <K>(K) => Ref<number>
 >;
-declare type MappedObj = $ObjMapi<
-  SourceObject,
-  <K>(K) => Ref<$ElementType<SourceObject, K>>
->;
-declare type ConstantKey = $PropertyType<MappedObj, \\"a\\">;
+declare type MappedObj = $ObjMapi<SourceObject, <K>(K) => Ref<SourceObject[K]>>;
+declare type ConstantKey = MappedObj[\\"a\\"];
 "
 `;

--- a/src/__tests__/__snapshots__/spread.spec.ts.snap
+++ b/src/__tests__/__snapshots__/spread.spec.ts.snap
@@ -7,7 +7,7 @@ declare var combination: Foo & Bar;
 "
 `;
 
-exports[`should use spread when performing union of object types 1`] = `
+exports[`should not use spread when performing union of inexact object types 1`] = `
 "declare type Foo = {
   foo: number,
   ...
@@ -16,11 +16,37 @@ declare type Bar = {
   bar: string,
   ...
 };
-declare var combination: { ...Foo, ...Bar };
+declare var combination: Foo & Bar;
 "
 `;
 
-exports[`should use spread when performing union of object types 2`] = `
+exports[`should not use spread when performing union of inexact object types 2`] = `
+"declare type Foo = {
+  foo: number,
+  ...
+};
+declare type Bar = {
+  bar: string,
+  ...
+};
+declare var combination: Foo & Bar;
+"
+`;
+
+exports[`should use spread when performing union of exact object types 1`] = `
+"declare type Foo = {
+  foo: number,
+  ...
+};
+declare type Bar = {
+  bar: string,
+  ...
+};
+declare var combination: Foo & Bar;
+"
+`;
+
+exports[`should use spread when performing union of exact object types 2`] = `
 "declare type Foo = {|
   foo: number,
 |};

--- a/src/__tests__/__snapshots__/spread.spec.ts.snap
+++ b/src/__tests__/__snapshots__/spread.spec.ts.snap
@@ -20,33 +20,7 @@ declare var combination: Foo & Bar;
 "
 `;
 
-exports[`should not use spread when performing union of inexact object types 2`] = `
-"declare type Foo = {
-  foo: number,
-  ...
-};
-declare type Bar = {
-  bar: string,
-  ...
-};
-declare var combination: Foo & Bar;
-"
-`;
-
 exports[`should use spread when performing union of exact object types 1`] = `
-"declare type Foo = {
-  foo: number,
-  ...
-};
-declare type Bar = {
-  bar: string,
-  ...
-};
-declare var combination: Foo & Bar;
-"
-`;
-
-exports[`should use spread when performing union of exact object types 2`] = `
 "declare type Foo = {|
   foo: number,
 |};

--- a/src/__tests__/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should handle Omit type 1`] = `
-"declare type A = $Diff<
+"declare type A = Omit<
   {
     a: string,
     b: number,
     ...
   },
-  { a: any }
+  \\"a\\"
 >;
-declare type B = $Diff<
+declare type B = Omit<
   {
     a: string,
     b: number,
     ...
   },
-  { a: any, b: any }
+  \\"a\\" | \\"b\\"
 >;
 declare type O = {
   a: string,
@@ -23,7 +23,7 @@ declare type O = {
   ...
 };
 declare type U = \\"a\\";
-declare type C = $Diff<O, { [key: U]: any }>;
+declare type C = Omit<O, U>;
 "
 `;
 
@@ -32,19 +32,20 @@ exports[`should handle utility types 1`] = `
   a: number,
   ...
 }>;
-declare type B = $Rest<
-  {
-    a: number,
-    ...
-  },
-  { ... }
->;
+declare type B = Partial<{
+  a: number,
+  ...
+}>;
 declare type C = $NonMaybeType<string | null>;
 declare type D = $ReadOnlyArray<string>;
-declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;
+declare type E = ReturnType<() => string>;
 declare type F = { [key: string]: number, ... };
 declare type G = $ReadOnlySet<number>;
 declare type H = $ReadOnlyMap<string, number>;
+declare type I = Pick<A, \\"foo\\" | \\"bar\\">;
+declare type J = Exclude<1 | 2 | 3 | 4, 1 | 3>;
+declare type K = Extract<A | B>;
+declare type L = Required<A>;
 declare type A1<Readonly> = Readonly;
 declare type B1<Partial> = Partial;
 declare type C1<NonNullable> = NonNullable;
@@ -52,10 +53,10 @@ declare type D1<ReadonlyArray> = ReadonlyArray;
 declare type E1<ReturnType> = ReturnType;
 declare type F1<Record> = Record;
 declare type A2<T> = $ReadOnly<T>;
-declare type B2<T> = $Rest<T, { ... }>;
+declare type B2<T> = Partial<T>;
 declare type C2<T> = $NonMaybeType<T>;
 declare type D2<T> = $ReadOnlyArray<T>;
-declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
+declare type E2<T> = ReturnType<() => T>;
 declare type F2<T, U> = { [key: T]: U, ... };
 "
 `;

--- a/src/__tests__/function-exports.spec.ts
+++ b/src/__tests__/function-exports.spec.ts
@@ -51,7 +51,7 @@ export function routerReducer(state?: RouterState): RouterState;
   expect(result).toBeValidFlowTypeDeclarations();
 });
 
-it("should remove this annotation from functions", () => {
+it("should keep this annotation in functions", () => {
   const ts =
     "function addClickListener(onclick: (this: void, e: Event) => void): void;";
   const result = compiler.compileDefinitionString(ts, { quiet: true });
@@ -59,9 +59,17 @@ it("should remove this annotation from functions", () => {
   expect(result).toBeValidFlowTypeDeclarations();
 });
 
-it("should remove default parameters from functions", () => {
+it("should keep default parameters in functions", () => {
   const ts =
     "function addClickListener<T = Error>(onclick: (e: Event) => void): T;";
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should transform generic `<T extends E>` to `<T: E>` on functions", () => {
+  const ts =
+    "function addClickListener<T extends Error>(onclick: (e: Event) => void): T;";
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();

--- a/src/__tests__/interfaces.spec.ts
+++ b/src/__tests__/interfaces.spec.ts
@@ -105,14 +105,14 @@ it("should support call signature", () => {
   expect(result).toBeValidFlowTypeDeclarations();
 });
 
-it("should remove this in call signature", () => {
+it("should keep this in call signature", () => {
   const ts = `
 interface Arc<This, Datum> {
   (this: This, d: Datum, ...args: any[]): string | null;
 }
   
 interface D<This, Datum> {
-  new (this: This, d: Datum, ...args: any[]);
+  new (this: D<This, Datum>, d: Datum, ...args: any[]);
 }
   
 interface C<This, Datum> {
@@ -124,7 +124,7 @@ interface C<This, Datum> {
   expect(result).toBeValidFlowTypeDeclarations();
 });
 
-it("should remove generic defaults in call signature", () => {
+it("should keep generic defaults in call signature", () => {
   const ts = `
 interface AbstractLevelDOWN<K, V> {}
 interface AbstractLevelDOWNConstructor {

--- a/src/__tests__/spread.spec.ts
+++ b/src/__tests__/spread.spec.ts
@@ -1,7 +1,7 @@
 import { compiler, beautify } from "..";
 import "../test-matchers";
 
-it("should use spread when performing union of object types", () => {
+it("should use spread when performing union of exact object types", () => {
   const ts = `
 type Foo = { foo: number };
 type Bar = { bar: string };
@@ -18,6 +18,29 @@ const combination: Foo & Bar;
     const result = compiler.compileDefinitionString(ts, {
       quiet: true,
       inexact: false,
+    });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+});
+
+it("should not use spread when performing union of inexact object types", () => {
+  const ts = `
+type Foo = { foo: number };
+type Bar = { bar: string };
+const combination: Foo & Bar;
+`;
+
+  {
+    const result = compiler.compileDefinitionString(ts, { quiet: true });
+    expect(beautify(result)).toMatchSnapshot();
+    expect(result).toBeValidFlowTypeDeclarations();
+  }
+
+  {
+    const result = compiler.compileDefinitionString(ts, {
+      quiet: true,
+      inexact: true,
     });
     expect(beautify(result)).toMatchSnapshot();
     expect(result).toBeValidFlowTypeDeclarations();

--- a/src/__tests__/spread.spec.ts
+++ b/src/__tests__/spread.spec.ts
@@ -7,21 +7,12 @@ type Foo = { foo: number };
 type Bar = { bar: string };
 const combination: Foo & Bar;
 `;
-
-  {
-    const result = compiler.compileDefinitionString(ts, { quiet: true });
-    expect(beautify(result)).toMatchSnapshot();
-    expect(result).toBeValidFlowTypeDeclarations();
-  }
-
-  {
-    const result = compiler.compileDefinitionString(ts, {
-      quiet: true,
-      inexact: false,
-    });
-    expect(beautify(result)).toMatchSnapshot();
-    expect(result).toBeValidFlowTypeDeclarations();
-  }
+  const result = compiler.compileDefinitionString(ts, {
+    quiet: true,
+    inexact: false,
+  });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should not use spread when performing union of inexact object types", () => {
@@ -30,21 +21,12 @@ type Foo = { foo: number };
 type Bar = { bar: string };
 const combination: Foo & Bar;
 `;
-
-  {
-    const result = compiler.compileDefinitionString(ts, { quiet: true });
-    expect(beautify(result)).toMatchSnapshot();
-    expect(result).toBeValidFlowTypeDeclarations();
-  }
-
-  {
-    const result = compiler.compileDefinitionString(ts, {
-      quiet: true,
-      inexact: true,
-    });
-    expect(beautify(result)).toMatchSnapshot();
-    expect(result).toBeValidFlowTypeDeclarations();
-  }
+  const result = compiler.compileDefinitionString(ts, {
+    quiet: true,
+    inexact: true,
+  });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
 });
 
 it("should not insert spread when performing union of class types", () => {

--- a/src/__tests__/utility-types.spec.ts
+++ b/src/__tests__/utility-types.spec.ts
@@ -11,6 +11,10 @@ type E = ReturnType<() => string>
 type F = Record<string, number>
 type G = ReadonlySet<number>
 type H = ReadonlyMap<string, number>
+type I = Pick<A, 'foo' | 'bar'>
+type J = Exclude<1 | 2 | 3 | 4, 1 | 3>
+type K = Extract<A | B>
+type L = Required<A>
 
 type A1<Readonly> = Readonly
 type B1<Partial> = Partial

--- a/src/printers/function.ts
+++ b/src/printers/function.ts
@@ -11,12 +11,8 @@ export const functionType = (
     | ts.ConstructSignatureDeclaration,
   dotAsReturn = false,
 ): string => {
-  const params = func.parameters
-    .filter(
-      param => !(ts.isIdentifier(param.name) && param.name.text === "this"),
-    )
-    .map(printers.common.parameter);
-  const generics = printers.common.genericsWithoutDefault(func.typeParameters);
+  const params = func.parameters.map(printers.common.parameter);
+  const generics = printers.common.generics(func.typeParameters);
   const returns = func.type ? printers.node.printType(func.type) : "void";
 
   const firstPass = `${generics}(${params.join(", ")})${

--- a/src/printers/identifiers.ts
+++ b/src/printers/identifiers.ts
@@ -38,24 +38,14 @@ const identifiers: { [name: string]: IdentifierResult } = {
   Readonly: "$ReadOnly",
   RegExpMatchArray: "RegExp$matchResult",
   NonNullable: "$NonMaybeType",
-  Partial: ([type]: any[]) => {
-    const isInexact = opts().inexact;
-    return `$Rest<${printers.node.printType(type)}, {${
-      isInexact ? "..." : ""
-    }}>`;
-  },
-  ReturnType: (typeArguments: any[]) => {
-    return `$Call<<R>((...args: any[]) => R) => R, ${printers.node.printType(
-      typeArguments[0],
-    )}>`;
-  },
+  Pick: "Pick",
+  Exclude: "Exclude",
+  Extract: "Extract",
+  Required: "Required",
+  Partial: "Partial",
+  ReturnType: "ReturnType",
   Record,
-  Omit: ([obj, keys]: [any, any]) => {
-    return `$Diff<${printers.node.printType(obj)},${Record(
-      [keys, { kind: ts.SyntaxKind.AnyKeyword }],
-      false,
-    )}>`;
-  },
+  Omit: "Omit",
 };
 
 export const print = withEnv<any, [string], IdentifierResult>((env, kind) => {

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -756,7 +756,7 @@ export const printType = withEnv<any, [any], string>(
         return "";
 
       case ts.SyntaxKind.IntersectionType: {
-        // for  exact types, we can't easily just merge types together
+        // for exact types we can't easily just intersect types together
         // using &. This is because in Typescript
         // { a: number } & { b: string}
         // is NOT equivalent to {| a: number |} & {| b: string |} in Flow

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -531,16 +531,7 @@ export const printType = withEnv<any, [any], string>(
         return "boolean";
 
       case ts.SyntaxKind.IndexedAccessType: {
-        let fn = "$ElementType";
-        if (
-          ts.isLiteralTypeNode(type.indexType) &&
-          type.indexType.literal.kind === ts.SyntaxKind.StringLiteral
-        ) {
-          fn = "$PropertyType";
-        }
-        return `${fn}<${printType(type.objectType)}, ${printType(
-          type.indexType,
-        )}>`;
+        return `${printType(type.objectType)}[${printType(type.indexType)}]`;
       }
 
       case ts.SyntaxKind.TypeOperator:

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -723,12 +723,8 @@ export const printType = withEnv<any, [any], string>(
 
       case ts.SyntaxKind.CallSignature: {
         // TODO: rewrite to printers.functions.functionType
-        const generics = printers.common.genericsWithoutDefault(
-          type.typeParameters,
-        );
+        const generics = printers.common.generics(type.typeParameters);
         const str = `${generics}(${type.parameters
-          // @ts-expect-error todo(flow->ts)
-          .filter(param => param.name.text !== "this")
           .map(printers.common.parameter)
           .join(", ")})`;
         // TODO: I can't understand this

--- a/yarn.lock
+++ b/yarn.lock
@@ -2082,9 +2082,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001286:
-  version "1.0.30001296"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz#d99f0f3bee66544800b93d261c4be55a35f1cec8"
-  integrity sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==
+  version "1.0.30001543"
+  resolved "https://npm.abs.sh/caniuse-lite/-/caniuse-lite-1.0.30001543.tgz"
+  integrity sha512-qxdO8KPWPQ+Zk6bvNpPeQIOH47qZSYdFZd6dXQzb2KzhnSXju4Kd7H1PkSJx6NICSMgo/IhRZRhhfPTHYpJUCA==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -2755,10 +2755,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
 
-flow-bin@^0.195.0:
-  version "0.195.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.0.tgz#67075596cc4ef2560ec001d5c781b07777f05f81"
-  integrity sha512-VGIwDVxcZRLbc2k8dsMcdHHjrPDzr1frqGvpRdYpdnpK/qi4heHFGDU747NElcsNiqyzs+G8gaZmhxZiBvwyUg==
+flow-bin@^0.217.2:
+  version "0.217.2"
+  resolved "https://npm.abs.sh/flow-bin/-/flow-bin-0.217.2.tgz#96affa17f3cb303019f740bffeb28cfab7ce1250"
+  integrity sha512-fk4NcfybYjzlww1sEsfk71nqXvonAYpMRFEjmZxibDWWBiaw8DGmqXWZ7XzSunVB15VkJfOstn/sYP1EYPPyWg==
 
 form-data@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Most of the utils which were not converted from TS are now natively supported in Flow.

I had to update the spread test as you can see, using spread for inexact object types now fails: [Flow Playground](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+IFkolXpUCWewUEAwhCQgRDH8wEH4hMnwROHlsNnw4KHwwSLAAC3wANyo4LFxscWQuHgMNZmwsiRSAWglaY1cq-hIAa2wJXNpG4Vxcdvdu3v7B0RxKUYMhKDBSqmbWwIq3eagoOrKSKgH0wtMMPznY7d2SfcoBiEZ-aG5G3Ix085AF-ZhsRoRehqUEiNMgSQHlSruBZxJrMcJwMhzAC+-EgGiCGiWVGwAAIWsYcQAxYg4gC8OOAAB0oDicTBiMgccIRDNeNTaVZOdSkQBuamY3DYvFrHEAISoZIp7JxmEojPspigCDZNJxnKs3L5UAFQuOOMgLPSkTg0EZwDVnOJEF4Fqs4soON5MRA+RMJBNUCC+QADFYAEwARgA7P6QEigA)

### new:

Pick: https://flow.org/en/docs/types/utilities/#toc-pick
Exclude: https://flow.org/en/docs/types/utilities/#toc-exclude
Extract: https://flow.org/en/docs/types/utilities/#toc-extract

### now natively supported:

Omit: https://flow.org/en/docs/types/utilities/#toc-omit
Partial: https://flow.org/en/docs/types/utilities/#toc-partial
Required: https://flow.org/en/docs/types/utilities/#toc-required

### this + default generic arguments are supported so don't need to be removed

### replace deprecated $ElementType and $PropertyType with indexed access types T[K]

https://flow.org/en/docs/types/utilities/#toc-propertytype
https://flow.org/en/docs/types/utilities/#toc-elementtype
