### PR TITLE
Allow scoped module names

### DIFF
--- a/src/__tests__/__snapshots__/asModule.spec.ts.snap
+++ b/src/__tests__/__snapshots__/asModule.spec.ts.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should wrap in module 1`] = `
+"declare module \\"myModule\\" {
+  declare type Test = \\"ok\\" | \\"error\\";
+  declare type Test2 = \\"ok\\" | \\"error\\";
+  declare type Maybe<T> =
+    | {
+        type: \\"just\\",
+        value: T,
+        ...
+      }
+    | {
+        type: \\"nothing\\",
+        ...
+      };
+  declare type Ref<T> = {
+    current: T,
+    ...
+  };
+  declare var ok: number;
+}
+"
+`;
+
+exports[`should wrap in module with scoped name 1`] = `
+"declare module \\"@company/project\\" {
+  declare type Test = \\"ok\\" | \\"error\\";
+  declare type Test2 = \\"ok\\" | \\"error\\";
+  declare type Maybe<T> =
+    | {
+        type: \\"just\\",
+        value: T,
+        ...
+      }
+    | {
+        type: \\"nothing\\",
+        ...
+      };
+  declare type Ref<T> = {
+    current: T,
+    ...
+  };
+  declare var ok: number;
+}
+"
+`;

--- a/src/__tests__/asModule.spec.ts
+++ b/src/__tests__/asModule.spec.ts
@@ -1,0 +1,30 @@
+import { compiler, beautify } from "..";
+import "../test-matchers";
+
+it("should wrap in module", () => {
+  const ts = `
+declare export type Test = 'ok' | 'error'
+declare type Test2 = 'ok' | 'error'
+type Maybe<T> = {type: 'just', value: T} | {type: 'nothing'}
+export type Ref<T> = { current: T }
+
+export const ok: number
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true, asModule: "myModule" });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should wrap in module with scoped name", () => {
+  const ts = `
+declare export type Test = 'ok' | 'error'
+declare type Test2 = 'ok' | 'error'
+type Maybe<T> = {type: 'just', value: T} | {type: 'nothing'}
+export type Ref<T> = { current: T }
+
+export const ok: number
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true, asModule: "@company/project" });
+  expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/parse/transformers.ts
+++ b/src/parse/transformers.ts
@@ -100,7 +100,7 @@ export function declarationFileTransform(options?: Options) {
         ctx.factory.createModuleDeclaration(
           undefined,
           undefined,
-          ctx.factory.createIdentifier(options.asModule),
+          ctx.factory.createStringLiteral(options.asModule),
           ctx.factory.createModuleBlock(
             node.statements.map(statement => {
               if (statement.modifiers) {


### PR DESCRIPTION
fixes #202 

Treat the module name as a string, rather than a typescript identifier. This lets you use scoped module names in the `--as-module` cli argument.
```
npx flowgen module.d.ts -o module.js --no-inexact --as-module '@company/module'
```

The flow output is like this:

```
declare module "@company/module" {
  declare export function myFunction();
}
```